### PR TITLE
Don't use an underscore in package name

### DIFF
--- a/accesscontrol/ac.go
+++ b/accesscontrol/ac.go
@@ -1,4 +1,4 @@
-package access_control
+package accesscontrol
 
 import "net/http"
 
@@ -6,8 +6,10 @@ var _ AccessControl = ValidateFunc(func(_ *http.Request) error { return nil })
 
 const ContextAccessControlKey = "access_controls"
 
-type Map map[string]AccessControl
-type List []AccessControl
+type (
+	Map  map[string]AccessControl
+	List []AccessControl
+)
 
 type ValidateFunc func(*http.Request) error
 

--- a/accesscontrol/jwt.go
+++ b/accesscontrol/jwt.go
@@ -1,4 +1,4 @@
-package access_control
+package accesscontrol
 
 import (
 	"context"

--- a/accesscontrol/jwt_algorithm.go
+++ b/accesscontrol/jwt_algorithm.go
@@ -1,4 +1,4 @@
-package access_control
+package accesscontrol
 
 const (
 	AlgorithmUnknown Algorithm = iota - 1

--- a/accesscontrol/jwt_test.go
+++ b/accesscontrol/jwt_test.go
@@ -1,4 +1,4 @@
-package access_control_test
+package accesscontrol_test
 
 import (
 	"crypto/rand"
@@ -13,7 +13,7 @@ import (
 
 	"github.com/dgrijalva/jwt-go/v4"
 
-	ac "github.com/avenga/couper/access_control"
+	ac "github.com/avenga/couper/accesscontrol"
 )
 
 func TestJWT_Validate(t *testing.T) {

--- a/config/runtime/handler.go
+++ b/config/runtime/handler.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/sirupsen/logrus"
 
-	ac "github.com/avenga/couper/access_control"
+	ac "github.com/avenga/couper/accesscontrol"
 	"github.com/avenga/couper/config"
 	"github.com/avenga/couper/errors"
 	"github.com/avenga/couper/handler"

--- a/eval/context.go
+++ b/eval/context.go
@@ -15,7 +15,7 @@ import (
 	"github.com/zclconf/go-cty/cty/function"
 	"github.com/zclconf/go-cty/cty/function/stdlib"
 
-	ac "github.com/avenga/couper/access_control"
+	ac "github.com/avenga/couper/accesscontrol"
 	"github.com/avenga/couper/config/request"
 	"github.com/avenga/couper/eval/lib"
 	"github.com/avenga/couper/internal/seetie"

--- a/handler/access_control.go
+++ b/handler/access_control.go
@@ -3,7 +3,7 @@ package handler
 import (
 	"net/http"
 
-	ac "github.com/avenga/couper/access_control"
+	ac "github.com/avenga/couper/accesscontrol"
 	"github.com/avenga/couper/errors"
 )
 

--- a/handler/access_control_test.go
+++ b/handler/access_control_test.go
@@ -6,13 +6,13 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/avenga/couper/access_control"
+	"github.com/avenga/couper/accesscontrol"
 	"github.com/avenga/couper/errors"
 )
 
 func TestAccessControl_ServeHTTP(t *testing.T) {
 	type fields struct {
-		ac        access_control.List
+		ac        accesscontrol.List
 		protected http.Handler
 	}
 
@@ -25,17 +25,17 @@ func TestAccessControl_ServeHTTP(t *testing.T) {
 		{"no access control", fields{nil, http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
 			rw.WriteHeader(http.StatusNoContent)
 		})}, httptest.NewRequest("GET", "http://ac.test/", nil), http.StatusNoContent},
-		{"with access control valid req", fields{access_control.List{access_control.ValidateFunc(func(r *http.Request) error {
+		{"with access control valid req", fields{accesscontrol.List{accesscontrol.ValidateFunc(func(r *http.Request) error {
 			return nil // valid
 		})}, http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
 			rw.WriteHeader(http.StatusNoContent)
 		})}, httptest.NewRequest("GET", "http://ac.test/", nil), http.StatusNoContent},
-		{"with access control invalid req/empty token", fields{access_control.List{access_control.ValidateFunc(func(r *http.Request) error {
-			return access_control.ErrorEmptyToken
+		{"with access control invalid req/empty token", fields{accesscontrol.List{accesscontrol.ValidateFunc(func(r *http.Request) error {
+			return accesscontrol.ErrorEmptyToken
 		})}, http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
 			rw.WriteHeader(http.StatusGone)
 		})}, httptest.NewRequest("GET", "http://ac.test/", nil), http.StatusUnauthorized},
-		{"with access control invalid req", fields{access_control.List{access_control.ValidateFunc(func(r *http.Request) error {
+		{"with access control invalid req", fields{accesscontrol.List{accesscontrol.ValidateFunc(func(r *http.Request) error {
 			return fmt.Errorf("no! ")
 		})}, http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
 			rw.WriteHeader(http.StatusGone)

--- a/server/muxer.go
+++ b/server/muxer.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"strings"
 
-	ac "github.com/avenga/couper/access_control"
+	ac "github.com/avenga/couper/accesscontrol"
 	"github.com/avenga/couper/config/runtime"
 	"github.com/avenga/couper/errors"
 	"github.com/avenga/couper/handler"


### PR DESCRIPTION
https://blog.golang.org/package-names

> Good package names are short and clear. They are lower case, with no under_scores or mixedCaps.

> Package names may be abbreviated when the abbreviation is familiar to the programmer.

So the package could be renamed to `ac` instead, it is even used as such:

```
import (
  ac "github.com/avenga/couper/access_control"
)
```