### PR TITLE
Update Wording

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,6 +1,6 @@
-# Couper 2
+# Couper
 
-Couper 2 is designed to support developers building and operating API-driven Web projects by offering security and observability functionality in a  lightweight API gateway component.
+Couper is designed to support developers building and operating API-driven Web projects by offering security and observability functionality in a frontend gateway component.
 
 _For additional information, tutorials and documentation please visit the [couper repository](https://github.com/avenga/couper)._
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Couper 2
+# Couper
 
 ![Go](https://github.com/avenga/couper/workflows/Go/badge.svg) | ![Docker](https://github.com/avenga/couper/workflows/Docker/badge.svg)
 
-Couper 2 is designed to support developers building and operating API-driven Web projects by offering security and observability functionality in a  lightweight API gateway component.
+Couper is designed to support developers building and operating API-driven Web projects by offering security and observability functionality in a frontend gateway component.
 
 * Tutorials: [couper examples](https://github.com/avenga/couper-examples)
 * Documentation: [docs](https://github.com/avenga/couper/tree/master/docs)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Couper 2 Docs - Version 0.1
+# Couper Docs - Version 0.1
 
 ## Table of contents
 
@@ -28,7 +28,7 @@
   * [`hosts` configuration](#hosts_conf_ex) 
    
 ## Introduction <a name="introduction"></a>
-Couper 2 is a lightweight API gateway especially designed to support building and running API-driven Web projects.
+Couper is a frontend gateway especially designed to support building and running API-driven Web projects.
 Acting as a proxy component it connects clients with (micro) services and adds access control and observability to the project. Couper does not need any special development skills and offers easy configuration and integration. 
 
 ## Core concepts <a name="core_concepts"></a>


### PR DESCRIPTION
Correction of version: Couper not Couper 2
Update term: "frontend" gateway instead of "lightweight API gateway"