### PR TITLE
Fix wildcard path join with trailing slash

### DIFF
--- a/handler/proxy.go
+++ b/handler/proxy.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -26,6 +25,7 @@ import (
 	"github.com/avenga/couper/eval"
 	"github.com/avenga/couper/internal/seetie"
 	"github.com/avenga/couper/logging"
+	"github.com/avenga/couper/utils"
 )
 
 var (
@@ -284,7 +284,7 @@ func (p *Proxy) director(req *http.Request) {
 
 	if pathMatch, ok := req.Context().
 		Value(request.Wildcard).(string); ok && strings.HasSuffix(p.options.Path, "/**") {
-		req.URL.Path = path.Join(strings.ReplaceAll(p.options.Path, "/**", "/"), pathMatch)
+		req.URL.Path = utils.JoinPath(strings.ReplaceAll(p.options.Path, "/**", "/"), pathMatch)
 	} else if p.options.Path != "" {
 		req.URL.Path = p.options.Path
 	}

--- a/handler/proxy_test.go
+++ b/handler/proxy_test.go
@@ -403,6 +403,7 @@ func TestProxy_director(t *testing.T) {
 		{"proxy url settings", fields{eval.NewENVContext(nil), log.WithContext(nil), &ProxyOptions{Origin: "http://1.2.3.4", Context: emptyOptions}}, defaultReq, httptest.NewRequest("GET", "http://1.2.3.4", nil)},
 		{"proxy url settings w/hostname", fields{eval.NewENVContext(nil), log.WithContext(nil), &ProxyOptions{Origin: "http://1.2.3.4", Hostname: "couper.io", Context: emptyOptions}}, defaultReq, httptest.NewRequest("GET", "http://couper.io", nil)},
 		{"proxy url settings w/wildcard ctx", fields{eval.NewENVContext(nil), log.WithContext(nil), &ProxyOptions{Origin: "http://1.2.3.4", Hostname: "couper.io", Path: "/**", Context: emptyOptions}}, defaultReq.WithContext(context.WithValue(defaultReq.Context(), request.Wildcard, "/hans")), httptest.NewRequest("GET", "http://couper.io/hans", nil)},
+		{"proxy url settings w/wildcard ctx trailing slash", fields{eval.NewENVContext(nil), log.WithContext(nil), &ProxyOptions{Origin: "http://1.2.3.4", Hostname: "couper.io", Path: "/**", Context: emptyOptions}}, defaultReq.WithContext(context.WithValue(defaultReq.Context(), request.Wildcard, "/docs/")), httptest.NewRequest("GET", "http://couper.io/docs/", nil)},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This will fix a wrong behaviour for wildcard path rewrites:

```hcl
api {
    base_path = "/api"

    backend {
      #inline
    }

    endpoint "/doc/**" {
      path = "/doc/**"
    }
}
```

which results in  `bereq.path: /doc` . Expected `/doc/` if `req.path` is `/api/doc/`