### PR TITLE
Fix write statusCode on first call to write

### DIFF
--- a/logging/status_recorder.go
+++ b/logging/status_recorder.go
@@ -25,6 +25,9 @@ func (sr *Recorder) Header() http.Header {
 
 // Write wraps the Write method of the ResponseWriter.
 func (sr *Recorder) Write(p []byte) (int, error) {
+	if sr.status == 0 {
+		sr.WriteHeader(http.StatusOK)
+	}
 	i, err := sr.rw.Write(p)
 	sr.writtenBytes += i
 	return i, err


### PR DESCRIPTION
This also prevents downloading the e.g. health status as gz, since the gzip implementation relies on the writeHeader call.

Fixes the health log