### PR TITLE
Fix handling cty null or unknown values during roundtrip eval #71

### DIFF
--- a/internal/seetie/convert.go
+++ b/internal/seetie/convert.go
@@ -21,11 +21,15 @@ func ExpToMap(ctx *hcl.EvalContext, exp hcl.Expression) (map[string]interface{},
 		return nil, filterErrors(diags)
 	}
 	result := make(map[string]interface{})
-	if val.IsNull() {
+	if val.IsNull() || !val.IsKnown() {
 		return result, nil
 	}
 
 	for k, v := range val.AsValueMap() {
+		if v.IsNull() || !v.IsKnown() {
+			result[k] = ""
+			continue
+		}
 		switch v.Type() {
 		case cty.Bool:
 			result[k] = v.True()


### PR DESCRIPTION
Closes #71 

As this would fix some current situations the evaluation handling for maps must be changed.

Evaluation of a map with multiple elements leads to an empty map if one item fails (e.g. *_headers or *query_params).