### PR TITLE
Fix openapi block handling for inline backends

### DIFF
--- a/config/backend.go
+++ b/config/backend.go
@@ -41,7 +41,10 @@ func (b Backend) Schema(inline bool) *hcl.BodySchema {
 		SetQueryParams     map[string]cty.Value `hcl:"set_query_params,optional"`
 	}
 
+	// TODO: handle block parsing on config load first
+	blocks := schema.Blocks
 	schema, _ = gohcl.ImpliedBodySchema(&Inline{})
+	schema.Blocks = blocks
 	return schema
 }
 

--- a/handler/proxy.go
+++ b/handler/proxy.go
@@ -712,10 +712,7 @@ func getAttribute(ctx *hcl.EvalContext, name string, body *hcl.BodyContent) stri
 	if _, ok := attr[name]; !ok {
 		return ""
 	}
-	originValue, diags := attr[name].Expr.Value(ctx)
-	if diags != nil && diags.HasErrors() {
-		panic(diags.Error())
-	}
+	originValue, _ := attr[name].Expr.Value(ctx)
 	return seetie.ValueToString(originValue)
 }
 

--- a/server/http_integration_test.go
+++ b/server/http_integration_test.go
@@ -764,3 +764,21 @@ func TestHTTPServer_Endpoint_Evaluation_Inheritance(t *testing.T) {
 		cleanup(shutdown, t)
 	}
 }
+
+func TestHTTPServer_Endpoint_Evaluation_Inheritance_Backend_Block(t *testing.T) {
+	helper := test.New(t)
+	client := newClient()
+
+	shutdown, _ := newCouper("testdata/integration/endpoint_eval/08_couper.hcl", test.New(t))
+
+	req, err := http.NewRequest(http.MethodGet, "http://example.com:8080/", nil)
+	helper.Must(err)
+
+	res, err := client.Do(req)
+	helper.Must(err)
+
+	if res.StatusCode != http.StatusBadRequest {
+		t.Error("Expected a bad request without required query param")
+	}
+	cleanup(shutdown, t)
+}

--- a/server/testdata/integration/endpoint_eval/08_couper.hcl
+++ b/server/testdata/integration/endpoint_eval/08_couper.hcl
@@ -1,0 +1,40 @@
+server "protected" {
+  error_file = "./../server_error.html"
+
+  api {
+    error_file = "./../api_error.json"
+
+    backend "anything" { # overrides definitions: backend "anything"
+      path = "/set/by/api/unset/by/endpoint"
+      openapi {
+        file = "also-not-there.yml"
+      }
+    }
+
+    endpoint "/" {
+      path = "/set/by/endpoint/unset/by/backend"
+      backend "anything" {
+        path = "/anything"
+        origin = "http://${req.path_params.origin}"
+        hostname = req.path_params.hostname
+        set_response_headers = {
+          x-origin = req.path_params.origin
+        }
+        openapi {
+          file = "08_schema.yaml"
+        }
+      }
+    }
+  }
+}
+
+definitions {
+  # backend origin within a definition block gets replaced with the integration test "anything" server.
+  backend "anything" {
+    path = "/not-found-anything"
+    origin = "http://anyserver/"
+    openapi {
+      file = "not-there.yml"
+    }
+  }
+}

--- a/server/testdata/integration/endpoint_eval/08_schema.yaml
+++ b/server/testdata/integration/endpoint_eval/08_schema.yaml
@@ -1,0 +1,16 @@
+openapi: '3'
+info:
+  title: 'Couper backend validation test'
+  version: 'v1.2.3'
+paths:
+  /anything:
+    get:
+      parameters:
+        - in: query
+          name: myparam
+          schema:
+            type: string
+          required: true
+      responses:
+        200:
+          description: OK


### PR DESCRIPTION
Temporary add this block to the inline definitions. Since inline eval relies on attributes this works for now
This must be done in a more cleaner and generic fashion considering other "static" attributes too.