### PR TITLE
Refactor: hcl evaluation context and related settings as own context obj

### DIFF
--- a/command/run.go
+++ b/command/run.go
@@ -47,7 +47,7 @@ func (r Run) Execute(args Args, config *config.Couper, logEntry *logrus.Entry) e
 		return err
 	}
 
-	serverList, listenCmdShutdown := server.NewServerList(r.context, logEntry.Logger, config.Settings, &timings, srvMux)
+	serverList, listenCmdShutdown := server.NewServerList(r.context, config.Context, logEntry.Logger, config.Settings, &timings, srvMux)
 	for _, srv := range serverList {
 		srv.Listen()
 	}

--- a/config/couper.go
+++ b/config/couper.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	"github.com/hashicorp/hcl/v2"
+	"github.com/avenga/couper/eval"
 )
 
 // DefaultFilename defines the default filename for a couper config file.
@@ -10,7 +10,7 @@ const DefaultFilename = "couper.hcl"
 // Couper represents the <Couper> config object.
 type Couper struct {
 	Bytes       []byte
-	Context     *hcl.EvalContext
+	Context     *eval.Context
 	Definitions *Definitions `hcl:"definitions,block"`
 	Servers     Servers      `hcl:"server,block"`
 	Settings    *Settings    `hcl:"settings,block"`

--- a/eval/http_test.go
+++ b/eval/http_test.go
@@ -1,0 +1,37 @@
+package eval_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/avenga/couper/errors"
+	"github.com/avenga/couper/eval"
+)
+
+func Test_SetGetBody_LimitBody(t *testing.T) {
+	type testCase struct {
+		name    string
+		limit   int64
+		payload string
+		wantErr error
+	}
+
+	for _, testcase := range []testCase{
+		{"/w well sized limit", 1024, "content", nil},
+		{"/w zero limit", 0, "01", errors.EndpointReqBodySizeExceeded},
+		{"/w limit /w oversize body", 4, "12345", errors.EndpointReqBodySizeExceeded},
+	} {
+		t.Run(testcase.name, func(subT *testing.T) {
+			req := httptest.NewRequest(http.MethodPut, "/", bytes.NewBufferString(testcase.payload))
+
+			err := eval.SetGetBody(req, testcase.limit)
+
+			if !reflect.DeepEqual(err, testcase.wantErr) {
+				subT.Errorf("Expected '%v', got: '%v'", testcase.wantErr, err)
+			}
+		})
+	}
+}

--- a/eval/lib/time_test.go
+++ b/eval/lib/time_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/avenga/couper/config/configload"
+	"github.com/avenga/couper/internal/test"
 )
 
 func TestUnixtime(t *testing.T) {
@@ -27,14 +28,16 @@ func TestUnixtime(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			helper := test.New(t)
 			cf, err := configload.LoadBytes([]byte(tt.hcl), "couper.hcl")
-			now, err := cf.Context.Functions["unixtime"].Call([]cty.Value{})
-			if err != nil {
-				t.Fatal(err)
-			}
+			helper.Must(err)
+			now, err := cf.Context.HCLContext().Functions["unixtime"].Call([]cty.Value{})
+			helper.Must(err)
+
 			if !cty.Number.Equals(now.Type()) {
 				t.Errorf("Wrong return type; expected %s, got: %s", cty.Number.FriendlyName(), now.Type().FriendlyName())
 			}
+
 			bfnow := now.AsBigFloat()
 			inow, _ := bfnow.Int64()
 			if inow != tt.want {

--- a/eval/reader.go
+++ b/eval/reader.go
@@ -1,0 +1,20 @@
+package eval
+
+import "io"
+
+type ReadCloser struct {
+	io.Reader
+	closer io.Closer
+}
+
+func NewReadCloser(r io.Reader, c io.Closer) *ReadCloser {
+	rc := &ReadCloser{Reader: r, closer: c}
+	return rc
+}
+
+func (rc ReadCloser) Close() error {
+	if rc.closer == nil {
+		return nil
+	}
+	return rc.closer.Close()
+}

--- a/eval/variables.go
+++ b/eval/variables.go
@@ -7,7 +7,7 @@ const (
 	BackendResponses = "beresps"
 	BackendDefault   = "default"
 	ClientRequest    = "req"
-	Context          = "ctx"
+	CTX              = "ctx"
 	Cookies          = "cookies"
 	Endpoint         = "endpoint"
 	Environment      = "env"

--- a/handler/producer/produce.go
+++ b/handler/producer/produce.go
@@ -3,8 +3,6 @@ package producer
 import (
 	"context"
 	"net/http"
-
-	"github.com/hashicorp/hcl/v2"
 )
 
 var (
@@ -13,5 +11,5 @@ var (
 )
 
 type Roundtrips interface {
-	Produce(ctx context.Context, req *http.Request, evalCtx *hcl.EvalContext, results chan<- *Result)
+	Produce(ctx context.Context, req *http.Request, results chan<- *Result)
 }

--- a/handler/producer/proxy.go
+++ b/handler/producer/proxy.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"net/http"
 	"sync"
-
-	"github.com/hashicorp/hcl/v2"
 )
 
 type Proxy struct {
@@ -15,7 +13,7 @@ type Proxy struct {
 
 type Proxies []*Proxy
 
-func (pr Proxies) Produce(ctx context.Context, clientReq *http.Request, _ *hcl.EvalContext, results chan<- *Result) {
+func (pr Proxies) Produce(ctx context.Context, clientReq *http.Request, results chan<- *Result) {
 	wg := &sync.WaitGroup{}
 	wg.Add(len(pr))
 	go func() {

--- a/handler/producer/result.go
+++ b/handler/producer/result.go
@@ -15,6 +15,16 @@ type Result struct {
 // Results represents the producer <Result> channel.
 type Results chan *Result
 
+type ResultMap map[string]*Result
+
+func (rm ResultMap) List() []*http.Response {
+	var list []*http.Response
+	for _, br := range rm {
+		list = append(list, br.Beresp)
+	}
+	return list
+}
+
 func roundtrip(rt http.RoundTripper, req *http.Request, results chan<- *Result, wg *sync.WaitGroup) {
 	defer wg.Done()
 

--- a/handler/transport/backend_test.go
+++ b/handler/transport/backend_test.go
@@ -59,7 +59,7 @@ func TestBackend_RoundTrip_Timings(t *testing.T) {
 			hook.Reset()
 
 			tt.tconf.NoProxyFromEnv = true // use origin addr from transport.Config
-			backend := transport.NewBackend(eval.NewENVContext(nil), tt.context, tt.tconf, log, nil)
+			backend := transport.NewBackend(tt.context, tt.tconf, log, nil)
 
 			_, err := backend.RoundTrip(tt.req)
 			if err != nil && tt.expectedErr == "" {
@@ -95,7 +95,7 @@ func TestBackend_Compression_Disabled(t *testing.T) {
 			"origin": hcltest.MockExprLiteral(u),
 		}),
 	})
-	backend := transport.NewBackend(eval.NewENVContext(nil), hclBody, &transport.Config{}, log, nil)
+	backend := transport.NewBackend(hclBody, &transport.Config{}, log, nil)
 
 	req := httptest.NewRequest(http.MethodOptions, "http://1.2.3.4/", nil)
 	res, err := backend.RoundTrip(req)
@@ -136,7 +136,7 @@ func TestBackend_Compression_ModifyAcceptEncoding(t *testing.T) {
 		}),
 	})
 
-	backend := transport.NewBackend(eval.NewENVContext(nil), hclBody, &transport.Config{
+	backend := transport.NewBackend(hclBody, &transport.Config{
 		Origin: origin.URL,
 	}, log, nil)
 
@@ -236,7 +236,7 @@ func TestBackend_RoundTrip_Validation(t *testing.T) {
 				origin = "` + origin.URL + `"
 			`)
 
-			backend := transport.NewBackend(eval.NewENVContext(nil), content, &transport.Config{}, log, openapiValidatorOptions)
+			backend := transport.NewBackend(content, &transport.Config{}, log, openapiValidatorOptions)
 
 			req := httptest.NewRequest(tt.requestMethod, "http://1.2.3.4"+tt.requestPath, nil)
 
@@ -311,7 +311,7 @@ func TestBackend_director(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			hclContext := helper.NewProxyContext(tt.inlineCtx)
 
-			backend := transport.NewBackend(eval.NewENVContext(nil), hclContext, &transport.Config{
+			backend := transport.NewBackend(hclContext, &transport.Config{
 				Timeout: time.Second,
 			}, nullLog, nil)
 
@@ -326,7 +326,7 @@ func TestBackend_director(t *testing.T) {
 			if !ok && tt.expReq.Host != req.Host {
 				t.Errorf("expected same host value, want: %q, got: %q", req.Host, tt.expReq.Host)
 			} else if ok {
-				hostVal, _ := hostnameExp.Expr.Value(eval.NewENVContext(nil))
+				hostVal, _ := hostnameExp.Expr.Value(eval.NewContext(nil).HCLContext())
 				hostname := seetie.ValueToString(hostVal)
 				if hostname != tt.expReq.Host {
 					t.Errorf("expected a configured request host: %q, got: %q", hostname, tt.expReq.Host)
@@ -396,7 +396,7 @@ func TestProxy_BufferingOptions(t *testing.T) {
 		t.Run(tc.name, func(st *testing.T) {
 			h := test.New(st)
 
-			backend := transport.NewBackend(eval.NewENVContext(nil), configload.MergeBodies([]hcl.Body{
+			backend := transport.NewBackend(configload.MergeBodies([]hcl.Body{
 				test.NewRemainContext("origin", "http://"+origin.Listener.Addr().String()),
 				helper.NewProxyContext(tc.remain),
 			}), &transport.Config{}, nullLog, newOptions())

--- a/handler/validation/openapi_test.go
+++ b/handler/validation/openapi_test.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/avenga/couper/config"
 	"github.com/avenga/couper/config/body"
-	"github.com/avenga/couper/eval"
 	"github.com/avenga/couper/handler/transport"
 	"github.com/avenga/couper/handler/validation"
 	"github.com/avenga/couper/internal/test"
@@ -60,9 +59,7 @@ func TestOpenAPIValidator_ValidateRequest(t *testing.T) {
 	openAPI, err := validation.NewOpenAPIOptions(beConf.OpenAPI)
 	helper.Must(err)
 
-	backend := transport.NewBackend(
-		eval.NewENVContext(nil), beConf.Remain, &transport.Config{}, logger, openAPI,
-	)
+	backend := transport.NewBackend(beConf.Remain, &transport.Config{}, logger, openAPI)
 
 	tests := []struct {
 		name, path string

--- a/internal/seetie/convert.go
+++ b/internal/seetie/convert.go
@@ -36,7 +36,7 @@ func ValueToMap(val cty.Value) map[string]interface{} {
 	}
 
 	for k, v := range valMap {
-		if v.IsNull() || !v.IsKnown() {
+		if v.IsNull() || !v.IsWhollyKnown() {
 			result[k] = ""
 			continue
 		}
@@ -50,6 +50,8 @@ func ValueToMap(val cty.Value) map[string]interface{} {
 		case cty.Number:
 			f, _ := v.AsBigFloat().Float64()
 			result[k] = f
+		case cty.Map(cty.NilType):
+			result[k] = ""
 		default:
 			if isTuple(v) {
 				result[k] = ValueToStringSlice(v)

--- a/internal/test/helper_proxy.go
+++ b/internal/test/helper_proxy.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"context"
+
 	"github.com/avenga/couper/handler/transport"
 
 	"github.com/hashicorp/hcl/v2"
@@ -29,10 +30,9 @@ func (h *Helper) NewProxy(conf *transport.Config, backendContext, proxyContext h
 		proxyCtx = hcl.EmptyBody()
 	}
 
-	evalCtx := eval.NewENVContext(nil)
-	backend := transport.NewBackend(evalCtx, backendContext, config, logger.WithContext(context.Background()), nil)
+	backend := transport.NewBackend(backendContext, config, logger.WithContext(context.Background()), nil)
 
-	proxy := handler.NewProxy(backend, proxyCtx, evalCtx)
+	proxy := handler.NewProxy(backend, proxyCtx)
 	return proxy
 }
 
@@ -42,6 +42,6 @@ func (h *Helper) NewProxyContext(inlineHCL string) hcl.Body {
 	}
 
 	var remain hclBody
-	h.Must(hclsimple.Decode(h.tb.Name()+".hcl", []byte(inlineHCL), eval.NewENVContext(nil), &remain))
+	h.Must(hclsimple.Decode(h.tb.Name()+".hcl", []byte(inlineHCL), eval.NewContext(nil).HCLContext(), &remain))
 	return configload.MergeBodies([]hcl.Body{remain.Inline})
 }

--- a/server/http.go
+++ b/server/http.go
@@ -11,10 +11,12 @@ import (
 	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 
+	ac "github.com/avenga/couper/accesscontrol"
 	"github.com/avenga/couper/config"
 	"github.com/avenga/couper/config/env"
 	"github.com/avenga/couper/config/request"
 	"github.com/avenga/couper/config/runtime"
+	"github.com/avenga/couper/eval"
 	"github.com/avenga/couper/handler"
 	"github.com/avenga/couper/handler/transport"
 	"github.com/avenga/couper/internal/test"
@@ -25,23 +27,24 @@ import (
 type HTTPServer struct {
 	accessLog  *logging.AccessLog
 	commandCtx context.Context
-	settings   *config.Settings
-	timings    *runtime.HTTPTimings
+	evalCtx    *eval.Context
 	listener   net.Listener
 	log        logrus.FieldLogger
 	mux        *Mux
 	port       string
+	settings   *config.Settings
 	shutdownCh chan struct{}
 	srv        *http.Server
+	timings    *runtime.HTTPTimings
 	uidFn      func() string
 }
 
 // NewServerList creates a list of all configured HTTP server.
-func NewServerList(cmdCtx context.Context, log logrus.FieldLogger, settings *config.Settings, timings *runtime.HTTPTimings, srvConf runtime.ServerConfiguration) ([]*HTTPServer, func()) {
+func NewServerList(cmdCtx context.Context, evalCtx *eval.Context, log logrus.FieldLogger, settings *config.Settings, timings *runtime.HTTPTimings, srvConf runtime.ServerConfiguration) ([]*HTTPServer, func()) {
 	var list []*HTTPServer
 
 	for port, srvMux := range srvConf {
-		list = append(list, New(cmdCtx, log, settings, timings, port, srvMux))
+		list = append(list, New(cmdCtx, evalCtx, log, settings, timings, port, srvMux))
 	}
 
 	handleShutdownFn := func() {
@@ -53,7 +56,7 @@ func NewServerList(cmdCtx context.Context, log logrus.FieldLogger, settings *con
 }
 
 // New creates a configured HTTP server.
-func New(cmdCtx context.Context, log logrus.FieldLogger, settings *config.Settings, timings *runtime.HTTPTimings, p runtime.Port, muxOpts *runtime.MuxOptions) *HTTPServer {
+func New(cmdCtx context.Context, evalCtx *eval.Context, log logrus.FieldLogger, settings *config.Settings, timings *runtime.HTTPTimings, p runtime.Port, muxOpts *runtime.MuxOptions) *HTTPServer {
 	var uidFn func() string
 	if settings.RequestIDFormat == "uuid4" {
 		uidFn = func() string {
@@ -75,6 +78,7 @@ func New(cmdCtx context.Context, log logrus.FieldLogger, settings *config.Settin
 	mux.MustAddRoute(http.MethodGet, settings.HealthPath, handler.NewHealthCheck(settings.HealthPath, shutdownCh))
 
 	httpSrv := &HTTPServer{
+		evalCtx:    evalCtx,
 		accessLog:  logging.NewAccessLog(&logConf, log),
 		commandCtx: cmdCtx,
 		log:        log,
@@ -176,9 +180,31 @@ func (s *HTTPServer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	)
 	rw = w
 
-	s.accessLog.ServeHTTP(rw, req, h, startTime)
+	if err := s.setGetBody(h, req); err != nil {
+		s.mux.opts.ErrorTpl.ServeError(err).ServeHTTP(rw, req)
+		return
+	}
+
+	ctx = s.evalCtx.WithClientRequest(req)
+	clientReq := req.Clone(ctx)
+
+	s.accessLog.ServeHTTP(rw, clientReq, h, startTime)
 
 	w.Close() // Closes the GZ writer.
+}
+
+func (s *HTTPServer) setGetBody(h http.Handler, req *http.Request) error {
+	outer := h
+	if inner, protected := outer.(ac.ProtectedHandler); protected {
+		outer = inner.Child()
+	}
+
+	if limitHandler, ok := h.(handler.EndpointLimit); ok {
+		if err := eval.SetGetBody(req, limitHandler.RequestLimit()); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // getHost configures the host from the incoming request host based on

--- a/server/http_test.go
+++ b/server/http_test.go
@@ -14,6 +14,8 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/avenga/couper/eval"
+
 	"github.com/avenga/couper/config"
 	"github.com/avenga/couper/config/configload"
 
@@ -70,7 +72,7 @@ func TestHTTPServer_ServeHTTP_Files(t *testing.T) {
 	helper.Must(err)
 
 	port := runtime.Port(conf.Settings.DefaultPort)
-	gw := server.New(ctx, log.WithContext(ctx), conf.Settings, &runtime.DefaultTimings, port, srvConf[port])
+	gw := server.New(ctx, conf.Context, log.WithContext(ctx), conf.Settings, &runtime.DefaultTimings, port, srvConf[port])
 	gw.Listen()
 	defer gw.Close()
 
@@ -162,7 +164,7 @@ func TestHTTPServer_ServeHTTP_Files2(t *testing.T) {
 	srvConf, err := runtime.NewServerConfiguration(conf, log.WithContext(nil))
 	helper.Must(err)
 
-	couper := server.New(ctx, log.WithContext(ctx), conf.Settings, &runtime.DefaultTimings, runtime.Port(0), srvConf[0])
+	couper := server.New(ctx, conf.Context, log.WithContext(ctx), conf.Settings, &runtime.DefaultTimings, runtime.Port(0), srvConf[0])
 	couper.Listen()
 	defer couper.Close()
 
@@ -251,7 +253,7 @@ func TestHTTPServer_ServeHTTP_UUID_Option(t *testing.T) {
 			log, hook := logrustest.NewNullLogger()
 			settings := config.DefaultSettings
 			settings.RequestIDFormat = testcase.formatOption
-			srv := server.New(context.Background(), log, &settings, &runtime.DefaultTimings, 0, nil)
+			srv := server.New(context.Background(), eval.NewContext(nil), log, &settings, &runtime.DefaultTimings, 0, nil)
 			srv.Listen()
 			defer srv.Close()
 


### PR DESCRIPTION
Attached to request which fixes the variable usage of non manipulated req and beresp* attributes

* at least at backend level