### PR TITLE
split docker entrypoint and command

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,7 +12,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
-1. Which Couper version? Run `couper version` or `docker run --entrypoint=/couper avenga/couper version`
+1. Which Couper version? Run `couper version` or `docker run avenga/couper version`
 
 2. Provide your configuration file `*.hcl`. Remove sensitive data.
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -7,12 +7,23 @@ _For additional information, tutorials and documentation please visit the [coupe
 ## Usage
 
 Couper requires a [configuration file](https://github.com/avenga/couper/tree/master/docs#conf_file) which have to be provided on start.
-See our [documentation](https://github.com/avenga/couper/tree/master/docs) how to configure _couper_. 
+See our [documentation](https://github.com/avenga/couper/tree/master/docs) how to configure _couper_.
 
 This image contains a basic configuration to serve files from `/htdocs` directory.
 
 ```bash
 docker run --rm -p 8080:8080 -v `pwd`:/htdocs avenga/couper
+```
+
+## Command
+
+The entrypoint of the image is the `/couper` binary. The command is `run`.
+
+Therefore `docker run avenga/couper` runs `/couper run`. You could also use other commands directly:
+
+```shell
+$ docker run avenga/couper version
+$ docker run avenga/couper run -watch -p 8081
 ```
 
 ### Environment options

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,5 @@ WORKDIR /conf
 ENV COUPER_LOG_FORMAT=json
 EXPOSE 8080
 USER 1000:1000
-ENTRYPOINT ["/couper", "run"]
+ENTRYPOINT ["/couper"]
+CMD ["run"]


### PR DESCRIPTION
to make it easier to give parameters:

```
$ docker run avenga/couper version
$ docker run avenga/couper run -p 1234
```
