### PR TITLE
Fix possible panic for unhandled template write errors

### DIFF
--- a/command/run.go
+++ b/command/run.go
@@ -9,6 +9,7 @@ import (
 	"github.com/avenga/couper/config"
 	"github.com/avenga/couper/config/env"
 	"github.com/avenga/couper/config/runtime"
+	"github.com/avenga/couper/errors"
 	"github.com/avenga/couper/server"
 	"github.com/sirupsen/logrus"
 )
@@ -63,6 +64,7 @@ func (r Run) Execute(args Args, config *config.Couper, logEntry *logrus.Entry) e
 	if err != nil {
 		return err
 	}
+	errors.SetLogger(logEntry)
 
 	serverList, listenCmdShutdown := server.NewServerList(r.context, config.Context, logEntry, config.Settings, &timings, srvConf)
 	for _, srv := range serverList {

--- a/config/runtime/server.go
+++ b/config/runtime/server.go
@@ -109,7 +109,7 @@ func NewServerConfiguration(
 	)
 
 	for _, srvConf := range conf.Servers {
-		serverOptions, err := server.NewServerOptions(srvConf)
+		serverOptions, err := server.NewServerOptions(srvConf, log)
 		if err != nil {
 			return nil, err
 		}
@@ -211,7 +211,7 @@ func NewServerConfiguration(
 			var errTpl *errors.Template
 
 			if endpointConf.ErrorFile != "" {
-				errTpl, err = errors.NewTemplateFromFile(endpointConf.ErrorFile)
+				errTpl, err = errors.NewTemplateFromFile(endpointConf.ErrorFile, log)
 				if err != nil {
 					return nil, err
 				}

--- a/config/runtime/server/options.go
+++ b/config/runtime/server/options.go
@@ -3,6 +3,8 @@ package server
 import (
 	"path"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/avenga/couper/config"
 	"github.com/avenga/couper/errors"
 	"github.com/avenga/couper/utils"
@@ -23,7 +25,7 @@ type Options struct {
 	ServerName    string
 }
 
-func NewServerOptions(conf *config.Server) (*Options, error) {
+func NewServerOptions(conf *config.Server, logger *logrus.Entry) (*Options, error) {
 	options := &Options{
 		FilesErrTpl:  errors.DefaultHTML,
 		ServerErrTpl: errors.DefaultHTML,
@@ -36,7 +38,7 @@ func NewServerOptions(conf *config.Server) (*Options, error) {
 	options.SrvBasePath = path.Join("/", conf.BasePath)
 
 	if conf.ErrorFile != "" {
-		tpl, err := errors.NewTemplateFromFile(conf.ErrorFile)
+		tpl, err := errors.NewTemplateFromFile(conf.ErrorFile, logger)
 		if err != nil {
 			return nil, err
 		}
@@ -53,7 +55,7 @@ func NewServerOptions(conf *config.Server) (*Options, error) {
 		options.APIBasePaths[api] = path.Join(options.SrvBasePath, api.BasePath)
 
 		if api.ErrorFile != "" {
-			tpl, err := errors.NewTemplateFromFile(api.ErrorFile)
+			tpl, err := errors.NewTemplateFromFile(api.ErrorFile, logger)
 			if err != nil {
 				return nil, err
 			}
@@ -65,7 +67,7 @@ func NewServerOptions(conf *config.Server) (*Options, error) {
 
 	if conf.Files != nil {
 		if conf.Files.ErrorFile != "" {
-			tpl, err := errors.NewTemplateFromFile(conf.Files.ErrorFile)
+			tpl, err := errors.NewTemplateFromFile(conf.Files.ErrorFile, logger)
 			if err != nil {
 				return nil, err
 			}

--- a/config/runtime/server_internal_test.go
+++ b/config/runtime/server_internal_test.go
@@ -54,7 +54,7 @@ func TestServer_getEndpointsList(t *testing.T) {
 		},
 	}
 
-	serverOptions, _ := server.NewServerOptions(nil)
+	serverOptions, _ := server.NewServerOptions(nil, nil)
 	endpoints, _ := newEndpointMap(srvConf, serverOptions)
 	if l := len(endpoints); l != 4 {
 		t.Fatalf("Expected 4 endpointes, given %d", l)

--- a/handler/file_test.go
+++ b/handler/file_test.go
@@ -39,7 +39,7 @@ func TestFile_ServeHTTP(t *testing.T) {
 		{"not found /w errorFile HEAD", fields{errFile: "testdata/file_err_doc.html"}, httptest.NewRequest(http.MethodHead, "http://domain.test/", nil), http.StatusNotFound},
 	}
 
-	srvOpts, _ := server.NewServerOptions(&config.Server{})
+	srvOpts, _ := server.NewServerOptions(&config.Server{}, nil)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/handler/spa_test.go
+++ b/handler/spa_test.go
@@ -31,7 +31,7 @@ func TestSpa_ServeHTTP(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			opts, _ := server.NewServerOptions(&config.Server{})
+			opts, _ := server.NewServerOptions(&config.Server{}, nil)
 			s, err := handler.NewSpa(path.Join(wd, tt.filePath), opts)
 			if err != nil {
 				t.Fatal(err)

--- a/server/mux_test.go
+++ b/server/mux_test.go
@@ -14,13 +14,12 @@ import (
 )
 
 func TestMux_FindHandler_PathParamContext(t *testing.T) {
-
 	type noContentHandler http.Handler
 	var noContent noContentHandler = http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		rw.WriteHeader(http.StatusNoContent)
 	})
 
-	serverOptions, _ := rs.NewServerOptions(nil)
+	serverOptions, _ := rs.NewServerOptions(nil, nil)
 
 	testOptions := &runtime.MuxOptions{
 		EndpointRoutes: map[string]http.Handler{


### PR DESCRIPTION
In this case a previously triggered error gets written to the client via error template, any write error would panic.
Pass the configured "daemon" logger and log those errors with the templates context.

This allows at least request/uid correlation.