### PR TITLE
use transport hostname instead for validation purposes

### DIFF
--- a/handler/transport/backend.go
+++ b/handler/transport/backend.go
@@ -157,7 +157,7 @@ func (b *Backend) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 func (b *Backend) openAPIValidate(req *http.Request, tc *Config, deadlineErr <-chan error) (*http.Response, error) {
-	requestValidationInput, err := b.openAPIValidator.ValidateRequest(req, tc.hash(), tc.Hostname)
+	requestValidationInput, err := b.openAPIValidator.ValidateRequest(req, tc.hash())
 	if err != nil {
 		return nil, errors.BackendValidation.Label(b.name).Kind("backend_request_validation").With(err)
 	}

--- a/handler/transport/backend.go
+++ b/handler/transport/backend.go
@@ -157,7 +157,7 @@ func (b *Backend) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 func (b *Backend) openAPIValidate(req *http.Request, tc *Config, deadlineErr <-chan error) (*http.Response, error) {
-	requestValidationInput, err := b.openAPIValidator.ValidateRequest(req, tc.hash(), tc.Scheme+"://"+tc.Origin)
+	requestValidationInput, err := b.openAPIValidator.ValidateRequest(req, tc.hash(), tc.Hostname)
 	if err != nil {
 		return nil, errors.BackendValidation.Label(b.name).Kind("backend_request_validation").With(err)
 	}

--- a/handler/validation/openapi_test.go
+++ b/handler/validation/openapi_test.go
@@ -178,7 +178,7 @@ func TestOpenAPIValidator_TemplateVariables(t *testing.T) {
 
 	for _, tc := range []testCase{
 		{name: "tpl url", origin: "https://api.example.com"},
-		{name: "relative url", origin: "https://api.example.com"},
+		{name: "relative url", origin: origin.Addr()},
 	} {
 		t.Run(tc.name, func(subT *testing.T) {
 			beConf := &config.Backend{

--- a/handler/validation/testdata/backend_03_openapi.yaml
+++ b/handler/validation/testdata/backend_03_openapi.yaml
@@ -3,8 +3,14 @@ info:
   title: 'Couper backend validation test: non-canonical server URL'
   version: 'v1.2.3'
 servers:
-  - url: https://httpbin.org/
-  - url: http://httpbin.org/
+  - url: 'http://api.example.com:12345'
+  - url: 'https://api.example.com:12345'
+  - url: 'https://api.example.com:443'
+  - url: 'https://api.example.com:80'
+  - url: 'http://api.example.com:443'
+  - url: 'http://api.example.com:80'
+  - url: 'http://api.example.com'
+  - url: 'https://api.example.com'
 paths:
   /anything:
     get:

--- a/handler/validation/testdata/backend_04_openapi.yaml
+++ b/handler/validation/testdata/backend_04_openapi.yaml
@@ -3,7 +3,7 @@ info:
   title: 'Couper backend validation test: template variables'
   version: 'v1.2.3'
 servers:
-  - url: 'http://api.example.com'
+  - url: '/anything'
     variables:
       sub:
         default: 'api'
@@ -12,7 +12,7 @@ servers:
       broken:
         default: https://api.example.com
 paths:
-  /anything:
+  /:
     get:
       responses:
         200:

--- a/handler/validation/testdata/backend_04_openapi.yaml
+++ b/handler/validation/testdata/backend_04_openapi.yaml
@@ -4,6 +4,7 @@ info:
   version: 'v1.2.3'
 servers:
   - url: '/anything'
+  - url: '/{sub}/anything'
     variables:
       sub:
         default: 'api'

--- a/handler/validation/testdata/backend_04_openapi.yaml
+++ b/handler/validation/testdata/backend_04_openapi.yaml
@@ -8,10 +8,14 @@ servers:
     variables:
       sub:
         default: 'api'
-  - url: '{broken/v1'
+  - url: 'http://{broken/v1'
     variables:
       broken:
         default: https://api.example.com
+  - url: 'https://{sub}.example.com/anything'
+    variables:
+      sub:
+        default: api
 paths:
   /:
     get:

--- a/handler/validation/testdata/backend_04_openapi.yaml
+++ b/handler/validation/testdata/backend_04_openapi.yaml
@@ -1,0 +1,19 @@
+openapi: '3'
+info:
+  title: 'Couper backend validation test: template variables'
+  version: 'v1.2.3'
+servers:
+  - url: 'http://api.example.com'
+    variables:
+      sub:
+        default: 'api'
+  - url: '{broken/v1'
+    variables:
+      broken:
+        default: https://api.example.com
+paths:
+  /anything:
+    get:
+      responses:
+        200:
+          description: OK


### PR DESCRIPTION
Skip relative url rewrite if variables are used `{...}`.