### PR TITLE
refine test for #233

### DIFF
--- a/server/http_endpoints_test.go
+++ b/server/http_endpoints_test.go
@@ -381,4 +381,18 @@ func TestEndpoints_DoNotExecuteResponseOnErrors(t *testing.T) {
 	if !bytes.Contains(resBytes, []byte("<html>configuration error</html>")) {
 		t.Errorf("Expected body '<html>configuration error</html>', given '%s'", resBytes)
 	}
+
+	// header from error handling is set
+	if v := res.Header.Get("couper-error"); v != "configuration error" {
+		t.Errorf("want couper-error 'configuration error', got %q", v)
+	}
+
+	// happy path headers not set
+	if res.Header.Get("x-backend") != "" {
+		t.Errorf("backend.set_response_headers should not have been run")
+	}
+
+	if res.Header.Get("x-endpoint") != "" {
+		t.Errorf("endpoint.set_response_headers should not have been run")
+	}
 }

--- a/server/testdata/endpoints/09_couper.hcl
+++ b/server/testdata/endpoints/09_couper.hcl
@@ -3,13 +3,25 @@ server "api" {
 
   endpoint "/" {
     proxy {
+      # should fail
       url = "https://foo.com"
 
       backend {
         origin = "https://bar.com"
+
+        # should not run
+        set_response_headers = {
+          x-backend = 1
+        }
       }
     }
 
+    # should not run
+    set_response_headers = {
+      x-endpoint = 1
+    }
+
+    # should not run
     response {
       body = "pest"
     }


### PR DESCRIPTION
proof that all actions after the error (set_response_headers…) will not
run