### PR TITLE
Fix possible status-code 0 write

### DIFF
--- a/errors/couper.go
+++ b/errors/couper.go
@@ -15,7 +15,7 @@ var (
 	BackendTimeout    = &Error{synopsis: "backend timeout error", httpStatus: http.StatusGatewayTimeout}
 	BackendValidation = &Error{synopsis: "backend validation error", httpStatus: http.StatusBadRequest}
 	ClientRequest     = &Error{synopsis: "client request error", httpStatus: http.StatusBadRequest}
-	Evaluation        = &Error{synopsis: "expression evaluation error", kinds: []string{"evaluation"}}
+	Evaluation        = &Error{synopsis: "expression evaluation error", kinds: []string{"evaluation"}, httpStatus: http.StatusInternalServerError}
 	Configuration     = &Error{synopsis: "configuration error", kinds: []string{"configuration"}, httpStatus: http.StatusInternalServerError}
 	Proxy             = &Error{synopsis: "proxy error", httpStatus: http.StatusBadGateway}
 	Request           = &Error{synopsis: "request error", httpStatus: http.StatusBadGateway}

--- a/errors/error.go
+++ b/errors/error.go
@@ -2,6 +2,7 @@ package errors
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 )
 
@@ -113,6 +114,9 @@ func (e *Error) LogError() string {
 
 // HTTPStatus returns the configured http status code this error should be served with.
 func (e *Error) HTTPStatus() int {
+	if e.httpStatus == 0 {
+		return http.StatusInternalServerError
+	}
 	return e.httpStatus
 }
 

--- a/errors/template.go
+++ b/errors/template.go
@@ -98,9 +98,6 @@ func (t *Template) ServeError(err error) http.Handler {
 		}
 
 		statusCode := goErr.HTTPStatus()
-		if statusCode == 0 {
-			statusCode = http.StatusInternalServerError
-		}
 
 		*req = *req.WithContext(context.WithValue(req.Context(), request.Error, goErr))
 

--- a/errors/template.go
+++ b/errors/template.go
@@ -96,6 +96,12 @@ func (t *Template) ServeError(err error) http.Handler {
 		if !ok {
 			goErr = Server.With(err)
 		}
+
+		statusCode := goErr.HTTPStatus()
+		if statusCode == 0 {
+			statusCode = http.StatusInternalServerError
+		}
+
 		*req = *req.WithContext(context.WithValue(req.Context(), request.Error, goErr))
 
 		rw.Header().Set(HeaderErrorCode, fmt.Sprintf(err.Error()))
@@ -104,7 +110,7 @@ func (t *Template) ServeError(err error) http.Handler {
 			t.ctxHandler.ServeHTTP(rw, req)
 		}
 
-		rw.WriteHeader(goErr.HTTPStatus())
+		rw.WriteHeader(statusCode)
 
 		if req.Method == http.MethodHead { // Its fine to send CT
 			return
@@ -115,7 +121,7 @@ func (t *Template) ServeError(err error) http.Handler {
 			reqID = r // could be nil within (unit) test cases
 		}
 		data := map[string]interface{}{
-			"http_status": goErr.HTTPStatus(),
+			"http_status": statusCode,
 			"message":     err.Error(),
 			"path":        req.URL.EscapedPath(),
 			"request_id":  escapeValue(t.mime, reqID),

--- a/errors/template_test.go
+++ b/errors/template_test.go
@@ -1,0 +1,39 @@
+package errors_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/avenga/couper/errors"
+	"github.com/avenga/couper/internal/test"
+	"github.com/avenga/couper/server"
+)
+
+func TestTemplate_ServeError(t1 *testing.T) {
+	log, _ := test.NewLogger()
+	errors.SetLogger(log.WithContext(context.Background()))
+
+	tests := []struct {
+		name      string
+		err       error
+		expStatus int
+	}{
+		{"error type with default status", errors.BasicAuth, http.StatusUnauthorized},
+		{"error type without status code /w fallback", errors.Evaluation, http.StatusInternalServerError},
+	}
+	for _, tt := range tests {
+		t1.Run(tt.name, func(t2 *testing.T) {
+			rec := server.NewRWWrapper(httptest.NewRecorder(), false, "")
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			errors.DefaultJSON.ServeError(tt.err).ServeHTTP(rec, req)
+
+			rec.Flush()
+
+			if rec.StatusCode() != tt.expStatus {
+				t2.Errorf("expected status %d, got: %d", tt.expStatus, rec.StatusCode())
+			}
+		})
+	}
+}

--- a/errors/template_test.go
+++ b/errors/template_test.go
@@ -21,7 +21,7 @@ func TestTemplate_ServeError(t1 *testing.T) {
 		expStatus int
 	}{
 		{"error type with default status", errors.BasicAuth, http.StatusUnauthorized},
-		{"error type without status code /w fallback", errors.Evaluation, http.StatusInternalServerError},
+		{"error type without status code /w fallback", &errors.Error{}, http.StatusInternalServerError},
 	}
 	for _, tt := range tests {
 		t1.Run(tt.name, func(t2 *testing.T) {


### PR DESCRIPTION
The error-template could not obtain the desired status-code from given error. This could lead to a panic if `responseWriter.WriteHeader(0)` is called explicitly.

In this case it is related to evaluation errors.

Fixed with adding a fallback to internal server error.