### PR TITLE
Fixup missing support for set_response_status within plain error_handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 Unreleased changes are available as `avenga/couper:edge` container.
 
+* **Fixed**
+  * missing support for `set_response_status` within a plain `error_handler` block ([#257](https://github.com/avenga/couper/pull/257))
+
 ---
 
 ## [1.3](https://github.com/avenga/couper/compare/1.2...1.3)
@@ -20,8 +23,6 @@ Unreleased changes are available as `avenga/couper:edge` container.
   * The `path` field in the backend log ([#232](https://github.com/avenga/couper/pull/232))
   * Upstream requests with a known body-size have a `Content-Length` HTTP header field instead of `Transfer-Encoding: chunked` ([#163](https://github.com/avenga/couper/issues/163))
   * Exit endpoint if an error is occurred in `request` or `proxy` instead of processing a defined `response` ([#233](https://github.com/avenga/couper/pull/233))
-
----
 
 ## [1.2](https://github.com/avenga/couper/compare/1.1.1...1.2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 Unreleased changes are available as `avenga/couper:edge` container.
 
 * **Fixed**
-  * missing support for `set_response_status` within a plain `error_handler` block ([#257](https://github.com/avenga/couper/pull/257))
+  * Missing support for `set_response_status` within a plain `error_handler` block ([#257](https://github.com/avenga/couper/pull/257))
 
 ---
 
@@ -17,7 +17,7 @@ Unreleased changes are available as `avenga/couper:edge` container.
 
 * **Changed**
   * Stronger configuration check for `path` and `path_prefix` attributes, possibly resulting in configuration errors ([#232](https://github.com/avenga/couper/pull/232))
-  * Modifier (`set/add/remove_response_headers`) is available for `api`, `files`, `server` and `spa` block too ([#248](https://github.com/avenga/couper/pull/248))
+  * Modifier (`set/add/remove_response_headers`) is available for `api`, `files`, `server` and `spa` block, too ([#248](https://github.com/avenga/couper/pull/248))
 
 * **Fixed**
   * The `path` field in the backend log ([#232](https://github.com/avenga/couper/pull/232))

--- a/eval/http.go
+++ b/eval/http.go
@@ -312,7 +312,7 @@ func ApplyResponseStatus(ctx context.Context, attr *hcl.Attribute, beresp *http.
 
 	val, attrDiags := attr.Expr.Value(httpCtx)
 	if seetie.SetSeverityLevel(attrDiags).HasErrors() {
-		return attrDiags, 0
+		return errors.Evaluation.With(attrDiags), 0
 	}
 
 	status := seetie.ValueToInt(val)

--- a/handler/endpoint.go
+++ b/handler/endpoint.go
@@ -167,12 +167,14 @@ func (e *Endpoint) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 		content, _, _ := e.opts.Context.PartialContent(config.Endpoint{}.Schema(true))
 		if attr, ok := content.Attributes["set_response_status"]; ok {
-			if _, statusCode := eval.ApplyResponseStatus(evalContext, attr, nil); statusCode > 0 {
+			if evalErr, statusCode := eval.ApplyResponseStatus(evalContext, attr, nil); statusCode > 0 {
 				if serr, k := serveErr.(*errors.Error); k {
 					serveErr = serr.Status(statusCode)
 				} else {
 					serveErr = errors.Server.With(serveErr).Status(statusCode)
 				}
+			} else if evalErr != nil {
+				e.log.WithError(errors.Evaluation.With(evalErr))
 			}
 		}
 

--- a/handler/endpoint.go
+++ b/handler/endpoint.go
@@ -167,14 +167,14 @@ func (e *Endpoint) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 		content, _, _ := e.opts.Context.PartialContent(config.Endpoint{}.Schema(true))
 		if attr, ok := content.Attributes["set_response_status"]; ok {
-			if evalErr, statusCode := eval.ApplyResponseStatus(evalContext, attr, nil); statusCode > 0 {
+			if applyErr, statusCode := eval.ApplyResponseStatus(evalContext, attr, nil); statusCode > 0 {
 				if serr, k := serveErr.(*errors.Error); k {
 					serveErr = serr.Status(statusCode)
 				} else {
 					serveErr = errors.Server.With(serveErr).Status(statusCode)
 				}
-			} else if evalErr != nil {
-				e.log.WithError(errors.Evaluation.With(evalErr))
+			} else if applyErr != nil {
+				e.log.WithError(applyErr)
 			}
 		}
 

--- a/server/modifier_test.go
+++ b/server/modifier_test.go
@@ -3,6 +3,7 @@ package server_test
 import (
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/avenga/couper/internal/test"
 )
@@ -84,17 +85,27 @@ func TestIntegration_SetResponseStatus(t *testing.T) {
 		{
 			path:       "/204",
 			expMessage: "set_response_status: removing body, if any due to status-code 204",
-			expStatus:  204,
+			expStatus:  http.StatusNoContent,
 		},
 		{
 			path:       "/201",
 			expMessage: "",
-			expStatus:  201,
+			expStatus:  http.StatusCreated,
 		},
 		{
 			path:       "/600",
 			expMessage: "configuration error: set_response_status: invalid http status code: 600",
-			expStatus:  500,
+			expStatus:  http.StatusInternalServerError,
+		},
+		{
+			path:       "/teapot",
+			expMessage: "access control error: ba: credentials required",
+			expStatus:  http.StatusTeapot,
+		},
+		{
+			path:       "/no-content",
+			expMessage: "", // logs without err have no/an empty message field
+			expStatus:  http.StatusNoContent,
 		},
 	} {
 		t.Run(tc.path, func(subT *testing.T) {
@@ -111,12 +122,13 @@ func TestIntegration_SetResponseStatus(t *testing.T) {
 				t.Errorf("Expected status code %d, given: %d", tc.expStatus, res.StatusCode)
 			}
 
+			time.Sleep(time.Second / 2) // MAYbe entries arent written yet
 			for _, entry := range hook.AllEntries() {
 				if entry.Message == tc.expMessage {
 					return
 				}
 			}
-			t.Errorf("expected log message not seen: %s", tc.expMessage)
+			t.Errorf("expected log message not seen: %s\ngot: %s", tc.expMessage, hook.LastEntry().Message)
 		})
 	}
 }

--- a/server/testdata/integration/modifier/02_couper.hcl
+++ b/server/testdata/integration/modifier/02_couper.hcl
@@ -23,4 +23,27 @@ server "set-response-status" {
       }
     }
   }
+
+  endpoint "/teapot" {
+    access_control = ["ba"]
+    response {}
+  }
+
+  endpoint "/no-content" {
+    response {
+      status = 500
+    }
+    set_response_status = 204
+  }
 }
+
+definitions {
+  basic_auth "ba" {
+    user = "hans"
+    password = "peter"
+    error_handler {
+      set_response_status = 418
+    }
+  }
+}
+


### PR DESCRIPTION
Previously a response block was required, now an existing AC error gets just the new status-code:

```hcl
definitions {
  basic_auth "ba" {
    user = "hans"
    password = "peter"
    error_handler {
      set_response_status = 418
    }
  }
}
```

While accessing related endpoints without credentials this configuration will still throw a `access control error: credentials required` but changes the status-code from `401` to `418`.

First implementation in #250