### PR TITLE
Fix log level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 Unreleased changes are available as `avenga/couper:edge` container.
 
+* **Changed**
+  * `Error` log-level for upstream responses with status `500` to `Info` log-level ([#258](https://github.com/avenga/couper/pull/258))
+
 * **Fixed**
   * Missing support for `set_response_status` within a plain `error_handler` block ([#257](https://github.com/avenga/couper/pull/257))
 

--- a/internal/test/test_backend.go
+++ b/internal/test/test_backend.go
@@ -31,6 +31,9 @@ func NewBackend() *Backend {
 	b.mux.HandleFunc("/", createAnythingHandler(http.StatusNotFound))
 	b.mux.HandleFunc("/ws", echo)
 	b.mux.HandleFunc("/pdf", pdf)
+	b.mux.HandleFunc("/error", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
 
 	return b
 }

--- a/logging/access_log.go
+++ b/logging/access_log.go
@@ -138,7 +138,7 @@ func (log *AccessLog) ServeHTTP(rw http.ResponseWriter, req *http.Request, nextH
 	entry := log.logger.WithFields(logrus.Fields(fields))
 	entry.Time = startTime
 
-	if statusCode == http.StatusInternalServerError || err != nil {
+	if err != nil {
 		entry.WithError(err).Error()
 	} else {
 		entry.Info()

--- a/logging/upstream_log.go
+++ b/logging/upstream_log.go
@@ -143,11 +143,9 @@ func (u *UpstreamLog) RoundTrip(req *http.Request) (*http.Response, error) {
 	entry := u.log.WithFields(logrus.Fields(fields))
 	entry.Time = startTime
 
-	if (beresp != nil && beresp.StatusCode == http.StatusInternalServerError) || err != nil {
-		if err != nil {
-			if _, ok := err.(errors.GoError); !ok {
-				err = errors.Backend.With(err)
-			}
+	if err != nil {
+		if _, ok := err.(errors.GoError); !ok {
+			err = errors.Backend.With(err)
 		}
 		entry.WithError(err).Error()
 	} else {

--- a/server/http_integration_test.go
+++ b/server/http_integration_test.go
@@ -2585,3 +2585,30 @@ func TestCORS_Configuration(t *testing.T) {
 		})
 	}
 }
+
+func TestLog_Level(t *testing.T) {
+	shutdown, hook := newCouper("testdata/integration/logging/01_couper.hcl", test.New(t))
+	defer shutdown()
+
+	client := newClient()
+
+	helper := test.New(t)
+
+	req, err := http.NewRequest(http.MethodGet, "http://my.upstream:8080/", nil)
+	helper.Must(err)
+
+	hook.Reset()
+
+	res, err := client.Do(req)
+	helper.Must(err)
+
+	if res.StatusCode != http.StatusInternalServerError {
+		t.Errorf("Expected status: %d, got: %d", http.StatusInternalServerError, res.StatusCode)
+	}
+
+	for _, entry := range hook.AllEntries() {
+		if entry.Level != logrus.InfoLevel {
+			t.Errorf("Expected info level, got: %v", entry.Level)
+		}
+	}
+}

--- a/server/testdata/integration/logging/01_couper.hcl
+++ b/server/testdata/integration/logging/01_couper.hcl
@@ -1,0 +1,21 @@
+server "couper" {
+  error_file = "./../server_error.html"
+
+  api {
+    error_file = "./../api_error.json"
+
+    endpoint "/" {
+      proxy {
+        backend = "anything"
+      }
+    }
+  }
+}
+
+definitions {
+  # backend origin within a definition block gets replaced with the integration test "anything" server.
+  backend "anything" {
+    path = "/error"
+    origin = env.COUPER_TEST_BACKEND_ADDR
+  }
+}


### PR DESCRIPTION
This changes the current behaviour to set the log-level for http-status-code 500 responses to `error`. This leads to wrong logs and maybe a log message with `<nil>` value since there is no error at all.