### PR TITLE
`couper.version` variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Unreleased changes are available as `avenga/couper:edge` container.
 
 * **Added**
   * [Run option](./docs/CLI.md#run-options) `-accept-forwarded-url` and [setting](./docs/REFERENCE.md#settings-block) `accept_forwarded_url` to accept `proto`, `host`, or `port` from `X-Forwarded-Proto`, `X-Forwarded-Host` or `X-Forwarded-Port` request headers, affecting new [client request variables](./docs/REFERENCE.md#request) `request.url`, `request.origin`, `request.protocol`, `request.host` and `request.port` ([#255](https://github.com/avenga/couper/pull/255))
-  * [`couper.version` variable](docs/REFERENCE.md#variables) ([#274](https://github.com/avenga/couper/pull/274))
+  * [`couper.version` variable](docs/REFERENCE.md#couper) ([#274](https://github.com/avenga/couper/pull/274))
 
 * **Fixed**
   * No GZIP compression for small response bodies ([#186](https://github.com/avenga/couper/issues/186))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Unreleased changes are available as `avenga/couper:edge` container.
 
 * **Added**
   * [Run option](./docs/CLI.md#run-options) `-accept-forwarded-url` and [setting](./docs/REFERENCE.md#settings-block) `accept_forwarded_url` to accept `proto`, `host`, or `port` from `X-Forwarded-Proto`, `X-Forwarded-Host` or `X-Forwarded-Port` request headers, affecting new [client request variables](./docs/REFERENCE.md#request) `request.url`, `request.origin`, `request.protocol`, `request.host` and `request.port` ([#255](https://github.com/avenga/couper/pull/255))
+  * [`couper.version` variable](docs/REFERENCE.md#variables) ([#274](https://github.com/avenga/couper/pull/274))
 
 * **Fixed**
   * No GZIP compression for small response bodies ([#186](https://github.com/avenga/couper/issues/186))

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /go/src/app
 COPY . .
 
 ENV GOFLAGS="-mod=vendor" \
-    VERSION_PACKAGE="github.com/avenga/couper/config/runtime"
+    VERSION_PACKAGE="github.com/avenga/couper/utils"
 
 RUN go generate && \
 	CGO_ENABLED=0 go build -v \

--- a/command/version.go
+++ b/command/version.go
@@ -4,7 +4,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/avenga/couper/config"
-	"github.com/avenga/couper/config/runtime"
+	"github.com/avenga/couper/utils"
 )
 
 var _ Cmd = &Version{}
@@ -16,7 +16,7 @@ func NewVersion() *Version {
 }
 
 func (v Version) Execute(_ Args, _ *config.Couper, _ *logrus.Entry) error {
-	println(runtime.VersionName + " " + runtime.BuildDate + " " + runtime.BuildName)
+	println(utils.VersionName + " " + utils.BuildDate + " " + utils.BuildName)
 	return nil
 }
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -27,6 +27,7 @@
   - [Access Control](#access-control)
   - [Health-Check](#health-check)
   - [Variables](#variables)
+    - [couper](#couper)
     - [env](#env)
     - [request](#request)
     - [backend_requests](#backend_requests)
@@ -474,6 +475,12 @@ The shutdown timings defaults to `0` which means no delaying with development se
 Both durations can be configured via environment variable. Please refer to the [docker document](./../DOCKER.md).
 
 ## Variables
+
+### `couper`
+
+| Variable                         | Description                                                                                                                                                                                                                                                                         |
+| :------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `version`                        | Couper's version number                                                                                                                                                                                                                                                             |
 
 ### `env`
 

--- a/eval/context.go
+++ b/eval/context.go
@@ -25,6 +25,7 @@ import (
 	"github.com/avenga/couper/config/request"
 	"github.com/avenga/couper/eval/lib"
 	"github.com/avenga/couper/internal/seetie"
+	"github.com/avenga/couper/utils"
 )
 
 type contextKey uint8
@@ -64,6 +65,7 @@ func NewContext(src []byte, defaults *config.Defaults) *Context {
 
 	variables := make(map[string]cty.Value)
 	variables[Environment] = newCtyEnvMap(envKeys, defaultEnvVariables)
+	variables[Couper] = newCtyCouperVariablesMap()
 
 	return &Context{
 		bufferOption: BufferRequest | BufferResponse, // TODO: eval per endpoint body route
@@ -419,6 +421,13 @@ func newCtyEnvMap(envKeys []string, defaultValues map[string]string) cty.Value {
 				ctyMap[key] = cty.StringVal("")
 			}
 		}
+	}
+	return cty.MapVal(ctyMap)
+}
+
+func newCtyCouperVariablesMap() cty.Value {
+	ctyMap := map[string]cty.Value{
+		"version": cty.StringVal(utils.VersionName),
 	}
 	return cty.MapVal(ctyMap)
 }

--- a/eval/context_test.go
+++ b/eval/context_test.go
@@ -235,6 +235,10 @@ func TestCouperVariables(t *testing.T) {
 			hclContext := cf.Context.Value(eval.ContextType).(*eval.Context).HCLContext()
 
 			couperVars := seetie.ValueToMap(hclContext.Variables["couper"])
+
+			if len(couperVars) != len(tt.want) {
+				t.Errorf("Unexpected 'couper' variables:\nWant:\t%q\nGot:\t%q", tt.want, couperVars)
+			}
 			for key, expectedValue := range tt.want {
 				value := couperVars[key]
 				if value != expectedValue {

--- a/eval/context_test.go
+++ b/eval/context_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/avenga/couper/eval"
 	"github.com/avenga/couper/internal/seetie"
 	"github.com/avenga/couper/internal/test"
+	"github.com/avenga/couper/utils"
 )
 
 func TestNewHTTPContext(t *testing.T) {
@@ -201,6 +202,43 @@ func TestDefaultEnvVariables(t *testing.T) {
 			for key, value := range envVars {
 				if _, isset := tt.want[key]; !isset {
 					t.Errorf("Unexpected variable %q in evironment: \nWant:\nGot:\t%s=%q", key, key, value)
+				}
+			}
+		})
+	}
+}
+
+func TestCouperVariables(t *testing.T) {
+	tests := []struct {
+		name string
+		hcl  string
+		want map[string]string
+	}{
+		{
+			"test",
+			`
+			server "test" {
+				api {}
+			}
+			`,
+			map[string]string{"version": utils.VersionName},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cf, err := configload.LoadBytes([]byte(tt.hcl), "couper.hcl")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			hclContext := cf.Context.Value(eval.ContextType).(*eval.Context).HCLContext()
+
+			couperVars := seetie.ValueToMap(hclContext.Variables["couper"])
+			for key, expectedValue := range tt.want {
+				value := couperVars[key]
+				if value != expectedValue {
+					t.Errorf("Unexpected value for variable:\nWant:\tcouper.%s=%q\nGot:\tcouper.%s=%q", key, expectedValue, key, value)
 				}
 			}
 		})

--- a/eval/variables.go
+++ b/eval/variables.go
@@ -24,4 +24,5 @@ const (
 	Protocol         = "protocol"
 	Host             = "host"
 	Port             = "port"
+	Couper           = "couper"
 )

--- a/main.go
+++ b/main.go
@@ -22,12 +22,13 @@ import (
 	"github.com/avenga/couper/config/runtime"
 	"github.com/avenga/couper/errors"
 	"github.com/avenga/couper/logging"
+	"github.com/avenga/couper/utils"
 )
 
 var (
 	fields = logrus.Fields{
-		"build":   runtime.BuildName,
-		"version": runtime.VersionName,
+		"build":   utils.BuildName,
+		"version": utils.VersionName,
 	}
 	testHook logrus.Hook
 )

--- a/utils/version.go
+++ b/utils/version.go
@@ -1,4 +1,4 @@
-package runtime
+package utils
 
 import "time"
 


### PR DESCRIPTION
Moved `VersionName`… to `utils` to break dependendy-cycle.