### PR TITLE
Accepted values in access log

### DIFF
--- a/logging/access_log.go
+++ b/logging/access_log.go
@@ -82,10 +82,8 @@ func (log *AccessLog) ServeHTTP(rw http.ResponseWriter, req *http.Request, nextH
 	}
 	requestFields["path"] = path.String()
 
-	if req.URL.Host != "" {
-		requestFields["addr"] = req.URL.Host
-		requestFields["host"], requestFields["port"] = splitHostPort(req.URL.Host)
-	}
+	requestFields["addr"] = req.URL.Host
+	requestFields["host"], requestFields["port"] = splitHostPort(req.URL.Host)
 
 	if req.URL.User != nil && req.URL.User.Username() != "" {
 		fields["auth_user"] = req.URL.User.Username()

--- a/logging/access_log.go
+++ b/logging/access_log.go
@@ -82,9 +82,9 @@ func (log *AccessLog) ServeHTTP(rw http.ResponseWriter, req *http.Request, nextH
 	}
 	requestFields["path"] = path.String()
 
-	if req.Host != "" {
-		requestFields["addr"] = req.Host
-		requestFields["host"], requestFields["port"] = splitHostPort(req.Host)
+	if req.URL.Host != "" {
+		requestFields["addr"] = req.URL.Host
+		requestFields["host"], requestFields["port"] = splitHostPort(req.URL.Host)
 	}
 
 	if req.URL.User != nil && req.URL.User.Username() != "" {
@@ -126,7 +126,7 @@ func (log *AccessLog) ServeHTTP(rw http.ResponseWriter, req *http.Request, nextH
 		}
 	}
 
-	fields["url"] = fields["scheme"].(string) + "://" + req.Host + path.String()
+	fields["url"] = fields["scheme"].(string) + "://" + req.URL.Host + path.String()
 
 	var err errors.GoError
 	fields["client_ip"], _ = splitHostPort(req.RemoteAddr)

--- a/server/http.go
+++ b/server/http.go
@@ -268,7 +268,11 @@ func (s *HTTPServer) setGetBody(h http.Handler, req *http.Request) error {
 func (s *HTTPServer) getHost(req *http.Request) string {
 	host := req.Host
 	if s.settings.XForwardedHost {
-		host = req.Header.Get("X-Forwarded-Host")
+		if xfh := req.Header.Get("X-Forwarded-Host"); xfh != "" {
+			host = xfh
+		} else {
+			s.log.Warnf("couper trying to use X-Forwarded-Host, but no X-Forwarded-Host request header found, using default host %s", host)
+		}
 	}
 
 	host = strings.ToLower(host)

--- a/server/http_integration_test.go
+++ b/server/http_integration_test.go
@@ -2628,7 +2628,7 @@ func getAllDaemonMessages(hook *logrustest.Hook) []string {
 
 func getAccessLogUrl(hook *logrustest.Hook) string {
 	for _, entry := range hook.AllEntries() {
-		if entry.Data["url"] != "" {
+		if entry.Data["type"] == "couper_access" && entry.Data["url"] != "" {
 			if url, ok := entry.Data["url"].(string); ok {
 				return url
 			}

--- a/server/http_integration_test.go
+++ b/server/http_integration_test.go
@@ -2195,7 +2195,7 @@ func TestHTTPServer_XFH_AcceptingForwardedUrl(t *testing.T) {
 			res, err := client.Do(req)
 			helper.Must(err)
 
-			resBytes, err := ioutil.ReadAll(res.Body)
+			resBytes, err := io.ReadAll(res.Body)
 			helper.Must(err)
 
 			_ = res.Body.Close()

--- a/server/http_integration_test.go
+++ b/server/http_integration_test.go
@@ -2079,6 +2079,155 @@ func TestHTTPServer_AcceptingForwardedUrl(t *testing.T) {
 	}
 }
 
+func TestHTTPServer_XFH_AcceptingForwardedUrl(t *testing.T) {
+	client := newClient()
+
+	confPath := path.Join("testdata/settings/06_couper.hcl")
+	shutdown, hook := newCouper(confPath, test.New(t))
+	defer shutdown()
+
+	type expectation struct {
+		Protocol string `json:"protocol"`
+		Host     string `json:"host"`
+		Port     int    `json:"port"`
+		Origin   string `json:"origin"`
+		Url      string `json:"url"`
+	}
+
+	type testCase struct {
+		name                  string
+		header                http.Header
+		exp                   expectation
+		wantDaemonLogMessages []string
+		wantAccessLogUrl      string
+	}
+
+	for _, tc := range []testCase{
+		{
+			"no proto, host, or port",
+			http.Header{},
+			expectation{
+				Protocol: "http",
+				Host:     "localhost",
+				Port:     8080,
+				Origin:   "http://localhost:8080",
+				Url:      "http://localhost:8080/path",
+			},
+			[]string{"couper trying to use X-Forwarded-Host, but no X-Forwarded-Host request header found, using default host localhost:8080", "couper accepting X-Forwarded-Proto, but no X-Forwarded-Proto request header found, using default protocol http", "couper accepting X-Forwarded-Port, but no X-Forwarded-Port request header found, using default port 8080"},
+			"http://localhost:8080/path",
+		},
+		{
+			"proto, host, no port",
+			http.Header{
+				"X-Forwarded-Proto": []string{"https"},
+				"X-Forwarded-Host":  []string{"www.example.com"},
+			},
+			expectation{
+				Protocol: "https",
+				Host:     "www.example.com",
+				Port:     443,
+				Origin:   "https://www.example.com",
+				Url:      "https://www.example.com/path",
+			},
+			[]string{"couper accepting X-Forwarded-Port, but no X-Forwarded-Port request header found, using default port "},
+			"https://www.example.com/path",
+		},
+		{
+			"proto, port, no host",
+			http.Header{
+				"X-Forwarded-Proto": []string{"https"},
+				"X-Forwarded-Port":  []string{"8443"},
+			},
+			expectation{
+				Protocol: "https",
+				Host:     "localhost",
+				Port:     8443,
+				Origin:   "https://localhost:8443",
+				Url:      "https://localhost:8443/path",
+			},
+			[]string{"couper trying to use X-Forwarded-Host, but no X-Forwarded-Host request header found, using default host localhost:8080"},
+			"https://localhost:8443/path",
+		},
+		{
+			"host, port, no proto",
+			http.Header{
+				"X-Forwarded-Host": []string{"www.example.com"},
+				"X-Forwarded-Port": []string{"8443"},
+			},
+			expectation{
+				Protocol: "http",
+				Host:     "www.example.com",
+				Port:     8443,
+				Origin:   "http://www.example.com:8443",
+				Url:      "http://www.example.com:8443/path",
+			},
+			[]string{"couper accepting X-Forwarded-Proto, but no X-Forwarded-Proto request header found, using default protocol http"},
+			"http://www.example.com:8443/path",
+		},
+		{
+			"proto, host, port",
+			http.Header{
+				"X-Forwarded-Proto": []string{"https"},
+				"X-Forwarded-Host":  []string{"www.example.com"},
+				"X-Forwarded-Port":  []string{"8443"},
+			},
+			expectation{
+				Protocol: "https",
+				Host:     "www.example.com",
+				Port:     8443,
+				Origin:   "https://www.example.com:8443",
+				Url:      "https://www.example.com:8443/path",
+			},
+			[]string{},
+			"https://www.example.com:8443/path",
+		},
+	} {
+		t.Run(tc.name, func(subT *testing.T) {
+			helper := test.New(subT)
+			hook.Reset()
+
+			req, err := http.NewRequest(http.MethodGet, "http://localhost:8080/path", nil)
+			helper.Must(err)
+			for k, v := range tc.header {
+				req.Header.Set(k, v[0])
+			}
+
+			res, err := client.Do(req)
+			helper.Must(err)
+
+			resBytes, err := ioutil.ReadAll(res.Body)
+			helper.Must(err)
+
+			_ = res.Body.Close()
+
+			var jsonResult expectation
+			err = json.Unmarshal(resBytes, &jsonResult)
+			if err != nil {
+				t.Errorf("unmarshal json: %v: got:\n%s", err, string(resBytes))
+			}
+			if !reflect.DeepEqual(jsonResult, tc.exp) {
+				t.Errorf("\nwant:\t%#v\ngot:\t%#v\npayload: %s", tc.exp, jsonResult, string(resBytes))
+			}
+
+			messages := getAllDaemonMessages(hook)
+			if len(messages) != len(tc.wantDaemonLogMessages) {
+				t.Errorf("Expected daemon messages: %#v, actual: %#v", tc.wantDaemonLogMessages, messages)
+			} else {
+				for i, msg := range messages {
+					if tc.wantDaemonLogMessages[i] != msg {
+						t.Errorf("Expected daemon messages: %#v, actual: %#v", tc.wantDaemonLogMessages[i], msg)
+					}
+				}
+			}
+
+			url := getAccessLogUrl(hook)
+			if url != tc.wantAccessLogUrl {
+				t.Errorf("Expected URL: %q, actual: %q", tc.wantAccessLogUrl, url)
+			}
+		})
+	}
+}
+
 func TestHTTPServer_Endpoint_Evaluation_Inheritance(t *testing.T) {
 	client := newClient()
 

--- a/server/testdata/settings/06_couper.hcl
+++ b/server/testdata/settings/06_couper.hcl
@@ -1,0 +1,11 @@
+server "accepting-forwarded-url" {
+  endpoint "/path" {
+    response {
+      json_body = request
+    }
+  }
+}
+settings {
+  xfh = true
+  accept_forwarded_url = [ "proto", "port" ]
+}


### PR DESCRIPTION
Even with `COUPER_ACCEPT_FORWARDED_URL=proto,host,port` the value of the `url` property of the entry in the `couper_access` log is not the proper "outer" URL: the host/port is always `localhost:8080`.
This PR fixes it.