### PR TITLE
Fix url parse related panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ Unreleased changes are available as `avenga/couper:edge` container.
   * [`backend_responses.<label>.status`](./docs/REFERENCE.md#backend_responses) is now integer ([#278](https://github.com/avenga/couper/pull/278))
   * [`backend_requests.<label>.form_body`](./docs/REFERENCE.md#backend_requests) was always empty ([#278](https://github.com/avenga/couper/pull/278))
   * Documentation of [`request.query.<name>`](./docs/REFERENCE.md#request) ([#278](https://github.com/avenga/couper/pull/278))
-  * Fix missing access log on some error cases ([#267](https://github.com/avenga/couper/issues/267))
+  * Missing access log on some error cases ([#267](https://github.com/avenga/couper/issues/267))
+  * Panic during backend origin / url usage with previous parse error ([#206](https://github.com/avenga/couper/issues/206))
 
 * [**Beta**](./docs/BETA.md)
   * OAuth2 Authorization Code Grant Flow: [`beta_oauth2 {}` block](./docs/REFERENCE.md#oauth2-ac-block-beta);  [`beta_oauth_authorization_url()`](./docs/REFERENCE.md#functions) and [`beta_oauth_verifier()`](./docs/REFERENCE.md#functions) ([#247](https://github.com/avenga/couper/pull/247))

--- a/handler/producer/result.go
+++ b/handler/producer/result.go
@@ -51,10 +51,10 @@ func roundtrip(rt http.RoundTripper, req *http.Request, results chan<- *Result, 
 			if rp == http.ErrAbortHandler {
 				err = errors.Proxy.Message("body copy failed")
 			} else {
-				err = &ResultPanic{
+				err = errors.Server.With(&ResultPanic{
 					err:   fmt.Errorf("%v", rp),
 					stack: debug.Stack(),
-				}
+				})
 			}
 			sendResult(req.Context(), results, &Result{
 				Err:           err,

--- a/handler/transport/backend.go
+++ b/handler/transport/backend.go
@@ -255,7 +255,7 @@ func (b *Backend) evalTransport(req *http.Request) (*Config, error) {
 
 	originURL, parseErr := url.Parse(origin)
 	if parseErr != nil {
-		log.WithError(parseErr).Error()
+		return nil, errors.Configuration.Label(b.name).With(parseErr)
 	} else if strings.HasPrefix(originURL.Host, originURL.Scheme+":") {
 		return nil, errors.Configuration.Label(b.name).
 			Messagef("invalid url: %s", originURL.String())
@@ -264,7 +264,7 @@ func (b *Backend) evalTransport(req *http.Request) (*Config, error) {
 	if rawURL, ok := req.Context().Value(request.URLAttribute).(string); ok {
 		urlAttr, err := url.Parse(rawURL)
 		if err != nil {
-			log.WithError(errors.Configuration.Label(b.name).With(err)).Error()
+			return nil, errors.Configuration.Label(b.name).With(err)
 		}
 
 		if origin != "" && urlAttr.Host != originURL.Host {

--- a/handler/transport/backend.go
+++ b/handler/transport/backend.go
@@ -233,7 +233,7 @@ func (b *Backend) evalTransport(req *http.Request) (*Config, error) {
 
 	content, _, diags := b.context.PartialContent(config.BackendInlineSchema)
 	if diags.HasErrors() {
-		log.WithError(errors.Evaluation.Label(b.name).With(diags)).Error()
+		return nil, errors.Evaluation.Label(b.name).With(diags)
 	}
 
 	var origin, hostname, proxyURL string


### PR DESCRIPTION
Wrap a recovered panic into a server error, which prevent sending the stack to the client
Exit on url errors

Closes #206 