### PR TITLE
Add missing documentation for https dev proxy setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Unreleased changes are available as `avenga/couper:edge` container.
   * Default values for environment variable by means of `environment_variables` within `defaults` block. ([#271](https://github.com/avenga/couper/pull/271))
   * `protocol`, `host`, `port`, `origin`, `body`, `json_body` to [`backend_requests`](./docs/REFERENCE.md#backend_requests) ([#278](https://github.com/avenga/couper/pull/278))
   * Settings for accepting a downstream requestID and use this ID instead for logging, `request.id` variable and down-/upstream id-header ([#268](https://github.com/avenga/couper/pull/268))
-  * `https-dev-proxy` option to map and proxy an existing port to a tls one; a SNI based on-the-fly generated certificate gets served from memory ([#281](https://github.com/avenga/couper/pull/281))
+  * [`https-dev-proxy` option](./docs/REFERENCE.md#settings-block) to listen and proxy from a given tls port to an existing Couper port; a SNI based on-the-fly generated certificate gets served from memory ([#281](https://github.com/avenga/couper/pull/281))
 
 * **Changed**
   * The `sp_acs_url` in the [SAML Block](./docs/REFERENCE.md#saml-block) may now be relative ([#265](https://github.com/avenga/couper/pull/265))

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -35,12 +35,13 @@ docker run avenga/couper run -watch -p 8081
 | COUPER_FILE                          | `couper.hcl` | Path to the configuration file. |
 | COUPER_WATCH                         | `false` | Set to `true` to watch for configuration file changes. |
 | COUPER_WATCH_RETRY_DELAY             | `500ms` | Delay duration before next attempt if an error occurs. |
-| COUPER_WATCH_RETRIES                 | `5` | Maximal retry count for configuration reloads which could not bind the configured port. |
-| COUPER_DEFAULT_PORT                  | `8080` | Sets the default port to the given value and does not override explicit `[host:port]` configurations from file. |
+| COUPER_WATCH_RETRIES                 | `5`     | Maximal retry count for configuration reloads which could not bind the configured port. |
+| COUPER_DEFAULT_PORT                  | `8080`  | Sets the default port to the given value and does not override explicit `[host:port]` configurations from file. |
 | COUPER_XFH                           | `false` | Global configurations which uses the `Forwarded-Host` header instead of the request host. |
 | COUPER_HEALTH_PATH                   | `/healthz` | Path for health-check requests for all servers and ports. |
+| COUPER_HTTPS_DEV_PROXY               | `""`    | List of tls port mappings to define the tls listen port and the target one. A self-signed certificate will be generated on the fly based on given hostname. |
 | COUPER_NO_PROXY_FROM_ENV             | `false` | Disables the connect hop to configured [proxy via environment](https://godoc.org/golang.org/x/net/http/httpproxy). |
-| COUPER_SECURE_COOKIES                | `""` | If set to `"strip"`, the `Secure` flag is removed from all `Set-Cookie` HTTP header fields. |
+| COUPER_SECURE_COOKIES                | `""`    | If set to `"strip"`, the `Secure` flag is removed from all `Set-Cookie` HTTP header fields. |
 |                                      | | |
 | COUPER_REQUEST_ID_FORMAT             | `common` | If set to `uuid4` a rfc4122 uuid is used for `request.id` and related log fields. |
 | COUPER_REQUEST_ID_ACCEPT_FROM_HEADER | `""` | Name of a client request HTTP header field that transports the `request.id` which Couper takes for logging and transport to the backend (if configured). |

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -31,3 +31,4 @@ _Note_: `log-format` and `log-pretty` also maps to [settings](REFERENCE.md#setti
 | Argument                | Default      | Environment                   | Description  |
 | :---------------------- | :----------- | :---------------------------- | :----------- |
 | `-accept-forwarded-url` | empty string | `COUPER_ACCEPT_FORWARDED_URL` | Which `X-Forwarded-*` request headers should be accepted to change the [variables](./REFERENCE.md#variables) `request.url`, `request.origin`, `request.protocol`, `request.host`, `request.port`. Comma-separated list of values. Valid values: `proto`, `host`, `port` |
+| `-https-dev-proxy`      | empty string | `COUPER_HTTPS_DEV_PROXY`      | List of tls port mappings to define the tls listen port and the target one. A self-signed certificate will be generated on the fly based on given hostname. |

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -445,7 +445,7 @@ gateway instance.
 | `accept_forwarded_url`          | list   | `[]`                | Which `X-Forwarded-*` request headers should be accepted to change the [variables](#variables) `request.url`, `request.origin`, `request.protocol`, `request.host`, `request.port`. Valid values: `proto`, `host`, `port` |-| `["proto","host","port"]` |
 | `default_port`                  | number | `8080`              | Port which will be used if not explicitly specified per host within the [`hosts`](#server-block) list. |-|-|
 | `health_path`                   | string | `/healthz`          | Health path which is available for all configured server and ports. |-|-|
-| `https_dev_proxy`               | list   | `""`                | List of tls port mappings to define the tls listen port and the target one. A self-signed certificate will be generated on the fly based on given hostname. | Certificates will be hold in memory and are generated once. | `["443:8080", "8443:8080"]` |
+| `https_dev_proxy`               | list   | `[]`                | List of tls port mappings to define the tls listen port and the target one. A self-signed certificate will be generated on the fly based on given hostname. | Certificates will be hold in memory and are generated once. | `["443:8080", "8443:8080"]` |
 | `log_format`                    | string | `common`            | Switch for tab/field based colored view or json log lines. |-|-|
 | `log_pretty`                    | bool   | `false`             | Global option for `json` log format which pretty prints with basic key coloring. |-|-|
 | `no_proxy_from_env`             | bool   | `false`             | Disables the connect hop to configured [proxy via environment](https://godoc.org/golang.org/x/net/http/httpproxy). |-|-|

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -445,6 +445,7 @@ gateway instance.
 | `accept_forwarded_url`          | list   | `[]`                | Which `X-Forwarded-*` request headers should be accepted to change the [variables](#variables) `request.url`, `request.origin`, `request.protocol`, `request.host`, `request.port`. Valid values: `proto`, `host`, `port` |-| `["proto","host","port"]` |
 | `default_port`                  | number | `8080`              | Port which will be used if not explicitly specified per host within the [`hosts`](#server-block) list. |-|-|
 | `health_path`                   | string | `/healthz`          | Health path which is available for all configured server and ports. |-|-|
+| `https_dev_proxy`               | list   | `""`                | List of tls port mappings to define the tls listen port and the target one. A self-signed certificate will be generated on the fly based on given hostname. | Certificates will be hold in memory and are generated once. | `["443:8080", "8443:8080"]` |
 | `log_format`                    | string | `common`            | Switch for tab/field based colored view or json log lines. |-|-|
 | `log_pretty`                    | bool   | `false`             | Global option for `json` log format which pretty prints with basic key coloring. |-|-|
 | `no_proxy_from_env`             | bool   | `false`             | Disables the connect hop to configured [proxy via environment](https://godoc.org/golang.org/x/net/http/httpproxy). |-|-|

--- a/server/tls.go
+++ b/server/tls.go
@@ -102,7 +102,7 @@ func NewTLSProxy(addr, port string, logger logrus.FieldLogger, settings *config.
 		ExpectContinueTimeout: 1 * time.Second,
 	}
 
-	headers := []string{"Connection", "Upgrade", "Forwarded"}
+	headers := []string{"Connection", "Upgrade"}
 	accessLog := logging.NewAccessLog(&logging.Config{
 		RequestHeaders:  append(logging.DefaultConfig.RequestHeaders, headers...),
 		ResponseHeaders: append(logging.DefaultConfig.ResponseHeaders, headers...),


### PR DESCRIPTION
Add missing documentation for https dev proxy setting introduces via https://github.com/avenga/couper/pull/281.