### PR TITLE
warnings of accept-forwarded-url features should not pollute logs

### DIFF
--- a/server/http.go
+++ b/server/http.go
@@ -216,8 +216,6 @@ func (s *HTTPServer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		if xfpr := req.Header.Get("X-Forwarded-Proto"); xfpr != "" {
 			clientReq.URL.Scheme = xfpr
 			clientReq.URL.Host = clientReq.URL.Hostname()
-		} else {
-			s.log.Warnf("couper accepting X-Forwarded-Proto, but no X-Forwarded-Proto request header found, using default protocol %s", clientReq.URL.Scheme)
 		}
 	}
 	if s.settings.AcceptsForwardedHost() {
@@ -226,15 +224,11 @@ func (s *HTTPServer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 			if clientReq.URL.Port() != "" {
 				clientReq.URL.Host += ":" + clientReq.URL.Port()
 			}
-		} else {
-			s.log.Warnf("couper accepting X-Forwarded-Host, but no X-Forwarded-Host request header found, using default host %s", clientReq.URL.Host)
 		}
 	}
 	if s.settings.AcceptsForwardedPort() {
 		if xfpo := req.Header.Get("X-Forwarded-Port"); xfpo != "" {
 			clientReq.URL.Host = clientReq.URL.Hostname() + ":" + xfpo
-		} else {
-			s.log.Warnf("couper accepting X-Forwarded-Port, but no X-Forwarded-Port request header found, using default port %s", clientReq.URL.Port())
 		}
 	}
 
@@ -265,8 +259,6 @@ func (s *HTTPServer) getHost(req *http.Request) string {
 	if s.settings.XForwardedHost {
 		if xfh := req.Header.Get("X-Forwarded-Host"); xfh != "" {
 			host = xfh
-		} else {
-			s.log.Warnf("couper trying to use X-Forwarded-Host, but no X-Forwarded-Host request header found, using default host %s", host)
 		}
 	}
 

--- a/server/http_integration_test.go
+++ b/server/http_integration_test.go
@@ -1959,11 +1959,10 @@ func TestHTTPServer_AcceptingForwardedUrl(t *testing.T) {
 	}
 
 	type testCase struct {
-		name                  string
-		header                http.Header
-		exp                   expectation
-		wantDaemonLogMessages []string
-		wantAccessLogUrl      string
+		name             string
+		header           http.Header
+		exp              expectation
+		wantAccessLogUrl string
 	}
 
 	for _, tc := range []testCase{
@@ -1977,7 +1976,6 @@ func TestHTTPServer_AcceptingForwardedUrl(t *testing.T) {
 				Origin:   "http://localhost:8080",
 				Url:      "http://localhost:8080/path",
 			},
-			[]string{"couper accepting X-Forwarded-Proto, but no X-Forwarded-Proto request header found, using default protocol http", "couper accepting X-Forwarded-Host, but no X-Forwarded-Host request header found, using default host localhost:8080", "couper accepting X-Forwarded-Port, but no X-Forwarded-Port request header found, using default port 8080"},
 			"http://localhost:8080/path",
 		},
 		{
@@ -1993,7 +1991,6 @@ func TestHTTPServer_AcceptingForwardedUrl(t *testing.T) {
 				Origin:   "https://www.example.com",
 				Url:      "https://www.example.com/path",
 			},
-			[]string{"couper accepting X-Forwarded-Port, but no X-Forwarded-Port request header found, using default port "},
 			"https://www.example.com/path",
 		},
 		{
@@ -2009,7 +2006,6 @@ func TestHTTPServer_AcceptingForwardedUrl(t *testing.T) {
 				Origin:   "https://localhost:8443",
 				Url:      "https://localhost:8443/path",
 			},
-			[]string{"couper accepting X-Forwarded-Host, but no X-Forwarded-Host request header found, using default host localhost"},
 			"https://localhost:8443/path",
 		},
 		{
@@ -2025,7 +2021,6 @@ func TestHTTPServer_AcceptingForwardedUrl(t *testing.T) {
 				Origin:   "http://www.example.com:8443",
 				Url:      "http://www.example.com:8443/path",
 			},
-			[]string{"couper accepting X-Forwarded-Proto, but no X-Forwarded-Proto request header found, using default protocol http"},
 			"http://www.example.com:8443/path",
 		},
 		{
@@ -2042,7 +2037,6 @@ func TestHTTPServer_AcceptingForwardedUrl(t *testing.T) {
 				Origin:   "https://www.example.com:8443",
 				Url:      "https://www.example.com:8443/path",
 			},
-			[]string{},
 			"https://www.example.com:8443/path",
 		},
 	} {
@@ -2071,17 +2065,6 @@ func TestHTTPServer_AcceptingForwardedUrl(t *testing.T) {
 			}
 			if !reflect.DeepEqual(jsonResult, tc.exp) {
 				t.Errorf("\nwant:\t%#v\ngot:\t%#v\npayload: %s", tc.exp, jsonResult, string(resBytes))
-			}
-
-			messages := getAllDaemonMessages(hook)
-			if len(messages) != len(tc.wantDaemonLogMessages) {
-				t.Errorf("Expected daemon messages: %#v, actual: %#v", tc.wantDaemonLogMessages, messages)
-			} else {
-				for i, msg := range messages {
-					if tc.wantDaemonLogMessages[i] != msg {
-						t.Errorf("Expected daemon messages: %#v, actual: %#v", tc.wantDaemonLogMessages[i], msg)
-					}
-				}
 			}
 
 			url := getAccessLogUrl(hook)
@@ -2108,11 +2091,10 @@ func TestHTTPServer_XFH_AcceptingForwardedUrl(t *testing.T) {
 	}
 
 	type testCase struct {
-		name                  string
-		header                http.Header
-		exp                   expectation
-		wantDaemonLogMessages []string
-		wantAccessLogUrl      string
+		name             string
+		header           http.Header
+		exp              expectation
+		wantAccessLogUrl string
 	}
 
 	for _, tc := range []testCase{
@@ -2126,7 +2108,6 @@ func TestHTTPServer_XFH_AcceptingForwardedUrl(t *testing.T) {
 				Origin:   "http://localhost:8080",
 				Url:      "http://localhost:8080/path",
 			},
-			[]string{"couper trying to use X-Forwarded-Host, but no X-Forwarded-Host request header found, using default host localhost:8080", "couper accepting X-Forwarded-Proto, but no X-Forwarded-Proto request header found, using default protocol http", "couper accepting X-Forwarded-Port, but no X-Forwarded-Port request header found, using default port 8080"},
 			"http://localhost:8080/path",
 		},
 		{
@@ -2142,7 +2123,6 @@ func TestHTTPServer_XFH_AcceptingForwardedUrl(t *testing.T) {
 				Origin:   "https://www.example.com",
 				Url:      "https://www.example.com/path",
 			},
-			[]string{"couper accepting X-Forwarded-Port, but no X-Forwarded-Port request header found, using default port "},
 			"https://www.example.com/path",
 		},
 		{
@@ -2158,7 +2138,6 @@ func TestHTTPServer_XFH_AcceptingForwardedUrl(t *testing.T) {
 				Origin:   "https://localhost:8443",
 				Url:      "https://localhost:8443/path",
 			},
-			[]string{"couper trying to use X-Forwarded-Host, but no X-Forwarded-Host request header found, using default host localhost:8080"},
 			"https://localhost:8443/path",
 		},
 		{
@@ -2174,7 +2153,6 @@ func TestHTTPServer_XFH_AcceptingForwardedUrl(t *testing.T) {
 				Origin:   "http://www.example.com:8443",
 				Url:      "http://www.example.com:8443/path",
 			},
-			[]string{"couper accepting X-Forwarded-Proto, but no X-Forwarded-Proto request header found, using default protocol http"},
 			"http://www.example.com:8443/path",
 		},
 		{
@@ -2191,7 +2169,6 @@ func TestHTTPServer_XFH_AcceptingForwardedUrl(t *testing.T) {
 				Origin:   "https://www.example.com:8443",
 				Url:      "https://www.example.com:8443/path",
 			},
-			[]string{},
 			"https://www.example.com:8443/path",
 		},
 	} {
@@ -2220,17 +2197,6 @@ func TestHTTPServer_XFH_AcceptingForwardedUrl(t *testing.T) {
 			}
 			if !reflect.DeepEqual(jsonResult, tc.exp) {
 				t.Errorf("\nwant:\t%#v\ngot:\t%#v\npayload: %s", tc.exp, jsonResult, string(resBytes))
-			}
-
-			messages := getAllDaemonMessages(hook)
-			if len(messages) != len(tc.wantDaemonLogMessages) {
-				t.Errorf("Expected daemon messages: %#v, actual: %#v", tc.wantDaemonLogMessages, messages)
-			} else {
-				for i, msg := range messages {
-					if tc.wantDaemonLogMessages[i] != msg {
-						t.Errorf("Expected daemon messages: %#v, actual: %#v", tc.wantDaemonLogMessages[i], msg)
-					}
-				}
 			}
 
 			url := getAccessLogUrl(hook)
@@ -2875,17 +2841,6 @@ func getAccessControlMessages(hook *logrustest.Hook) string {
 	}
 
 	return ""
-}
-
-func getAllDaemonMessages(hook *logrustest.Hook) []string {
-	var msgs []string
-	for _, entry := range hook.AllEntries() {
-		if entry.Message != "" {
-			msgs = append(msgs, entry.Message)
-		}
-	}
-
-	return msgs
 }
 
 func getAccessLogUrl(hook *logrustest.Hook) string {


### PR DESCRIPTION
If Couper is configured to use `x-forwarded-host` header to determine its URL, every incoming request that does not have this header, results in the same warning being logged:

```
couper accepting X-Forwarded-Host, but no X-Forwarded-Host request header found, using default host localhost:8080
```

This pollutes the log files, especially for health check requests to `/healthz`. These are often carried out by an agent behind the TLS offloader. E.g. in Kubernetes, the `kube-probe` agent sending the `livenessProbe` does not use the Ingress which would add the XFH header.

This M/R removes the warning from the log.

As the interpreted hostname is logged in the access log, we don't loose the ability to check whether the XF* configuration works.