### PR TITLE
Fix statusCode 0 write panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Unreleased changes are available as `avenga/couper:edge` container.
   * Documentation of [`request.query.<name>`](./docs/REFERENCE.md#request) ([#278](https://github.com/avenga/couper/pull/278))
   * Missing access log on some error cases ([#267](https://github.com/avenga/couper/issues/267))
   * Panic during backend origin / url usage with previous parse error ([#206](https://github.com/avenga/couper/issues/206))
+  * Missing error handling for backend gzip header reads ([#291](https://github.com/avenga/couper/pull/291))
+  * ResponseWriter fallback for possible statusCode 0 writes ([#291](https://github.com/avenga/couper/pull/291))
 
 * [**Beta**](./docs/BETA.md)
   * OAuth2 Authorization Code Grant Flow: [`beta_oauth2 {}` block](./docs/REFERENCE.md#oauth2-ac-block-beta);  [`beta_oauth_authorization_url()`](./docs/REFERENCE.md#functions) and [`beta_oauth_verifier()`](./docs/REFERENCE.md#functions) ([#247](https://github.com/avenga/couper/pull/247))

--- a/eval/buffer.go
+++ b/eval/buffer.go
@@ -34,6 +34,10 @@ func (i BufferOption) GoString() string {
 func MustBuffer(body hcl.Body) BufferOption {
 	result := BufferNone
 
+	if body == nil {
+		return result
+	}
+
 	attrs, err := body.JustAttributes()
 	if err != nil {
 		return result

--- a/eval/context.go
+++ b/eval/context.go
@@ -185,6 +185,7 @@ func (c *Context) WithBeresps(beresps ...*http.Response) *Context {
 		if n, ok := bereq.Context().Value(request.RoundTripName).(string); ok {
 			name = n
 		}
+
 		p := bereq.URL.Port()
 		if p == "" {
 			if bereq.URL.Scheme == "https" {
@@ -194,6 +195,7 @@ func (c *Context) WithBeresps(beresps ...*http.Response) *Context {
 			}
 		}
 		port, _ := strconv.ParseInt(p, 10, 64)
+
 		body, jsonBody := parseReqBody(bereq)
 		bereqs[name] = cty.ObjectVal(ContextMap{
 			Method:   cty.StringVal(bereq.Method),

--- a/handler/endpoint_test.go
+++ b/handler/endpoint_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsimple"
 	logrustest "github.com/sirupsen/logrus/hooks/test"
 
+	"github.com/avenga/couper/config/request"
 	"github.com/avenga/couper/errors"
 	"github.com/avenga/couper/eval"
 	"github.com/avenga/couper/handler"
@@ -20,6 +21,7 @@ import (
 	"github.com/avenga/couper/handler/transport"
 	"github.com/avenga/couper/internal/test"
 	"github.com/avenga/couper/server/writer"
+	"github.com/sirupsen/logrus"
 )
 
 func TestEndpoint_RoundTrip_Eval(t *testing.T) {
@@ -242,7 +244,7 @@ func TestEndpoint_RoundTripContext_Variables_json_body(t *testing.T) {
 	}
 }
 
-// TestProxy_SetRoundtripContext_Null_Eval tests the handling with non existing references or cty.Null evaluations.
+// TestProxy_SetRoundtripContext_Null_Eval tests the handling with non-existing references or cty.Null evaluations.
 func TestEndpoint_RoundTripContext_Null_Eval(t *testing.T) {
 	helper := test.New(t)
 
@@ -363,4 +365,90 @@ func TestEndpoint_RoundTripContext_Null_Eval(t *testing.T) {
 		})
 
 	}
+}
+
+type mockProducerResult struct {
+	rt http.RoundTripper
+}
+
+func (m *mockProducerResult) Produce(_ context.Context, r *http.Request, results chan<- *producer.Result) {
+	if m == nil || m.rt == nil {
+		close(results)
+		return
+	}
+
+	res, err := m.rt.RoundTrip(r)
+	results <- &producer.Result{
+		RoundTripName: "default",
+		Beresp:        res,
+		Err:           err,
+	}
+	close(results)
+}
+
+func TestEndpoint_ServeHTTP_FaultyDefaultResponse(t *testing.T) {
+	log, hook := test.NewLogger()
+
+	origin := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		png := []byte(`�PNG
+
+
+IHDRH0=���gAMA���a	pHYs���B��tEXtSoftwarePaint.NET v3.5.100�r�pIDAThC���	�0���b!K�$�������1x={+��^��h
+�)��6���z�Qj�h
+�)��0�N4��FS�7l�5��"Ma4��F�=q���ь�FS�7l|�Ұ��nW�i�0IEND�B`)
+
+		rw.Header().Set("Content-Encoding", "gzip")  // wrong
+		rw.Header().Set("Content-Type", "text/html") // wrong
+		rw.Header().Set("Cache-Control", "no-cache, no-store, max-age=0")
+
+		_, err := rw.Write(png)
+		if err != nil {
+			t.Error(err)
+		}
+	}))
+	defer origin.Close()
+
+	rt := transport.NewBackend(
+		test.NewRemainContext("origin", origin.URL), &transport.Config{},
+		&transport.BackendOptions{}, log.WithContext(context.Background()))
+
+	mockProducer := &mockProducerResult{rt}
+
+	ep := handler.NewEndpoint(&handler.EndpointOptions{
+		Context:  hcl.EmptyBody(),
+		Error:    errors.DefaultJSON,
+		Requests: mockProducer,
+		Proxies:  &mockProducerResult{},
+	}, log.WithContext(context.Background()), nil)
+
+	ctx := context.Background()
+	req := httptest.NewRequest(http.MethodGet, "http://", nil).WithContext(ctx)
+	ctx = eval.NewContext(nil, nil).WithClientRequest(req)
+	ctx = context.WithValue(ctx, request.UID, "test123")
+
+	rec := transport.NewRecorder()
+	rw := writer.NewResponseWriter(rec, "")
+	ep.ServeHTTP(rw, req.Clone(ctx))
+	res, err := rec.Response(req)
+	if err != nil {
+		t.Error(err)
+	}
+	if res.StatusCode == 0 {
+		t.Errorf("Fatal error: response status is zero")
+		if res.Header.Get("Couper-Error") != "internal server error" {
+			t.Errorf("Expected internal server error, got: %s", res.Header.Get("Couper-Error"))
+		}
+	} else if res.StatusCode != http.StatusOK {
+		t.Errorf("Expected status ok, got: %v", res.StatusCode)
+	}
+
+	for _, e := range hook.AllEntries() {
+		if e.Level != logrus.ErrorLevel {
+			continue
+		}
+		if e.Message != "backend error: body reset: gzip: invalid header" {
+			t.Errorf("Unexpected error message: %s", e.Message)
+		}
+	}
+
 }

--- a/internal/test/log.go
+++ b/internal/test/log.go
@@ -7,12 +7,14 @@ import (
 	logrustest "github.com/sirupsen/logrus/hooks/test"
 
 	"github.com/avenga/couper/errors"
+	"github.com/avenga/couper/logging"
 )
 
 func NewLogger() (*logrus.Logger, *logrustest.Hook) {
 	log := logrus.New()
 	log.Out = io.Discard
 	log.AddHook(&errors.LogHook{})
+	log.AddHook(&logging.ContextHook{})
 	hook := logrustest.NewLocal(log)
 	return log, hook
 }

--- a/logging/context_hook.go
+++ b/logging/context_hook.go
@@ -1,0 +1,26 @@
+package logging
+
+import (
+	"github.com/sirupsen/logrus"
+
+	"github.com/avenga/couper/config/request"
+)
+
+var _ logrus.Hook = &ContextHook{}
+
+type ContextHook struct {
+}
+
+func (c ContextHook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+func (c ContextHook) Fire(entry *logrus.Entry) error {
+	_, exist := entry.Data["uid"]
+	if entry.Context != nil && !exist {
+		if uid := entry.Context.Value(request.UID); uid != nil {
+			entry.Data["uid"] = uid
+		}
+	}
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -197,6 +197,7 @@ func newLogger(format string, pretty bool) *logrus.Entry {
 	logger.Out = os.Stdout
 
 	logger.AddHook(&errors.LogHook{})
+	logger.AddHook(&logging.ContextHook{})
 
 	if testHook != nil {
 		logger.AddHook(testHook)

--- a/server/writer/response.go
+++ b/server/writer/response.go
@@ -9,6 +9,7 @@ import (
 	"net/textproto"
 	"strconv"
 
+	"github.com/avenga/couper/errors"
 	"github.com/avenga/couper/eval"
 	"github.com/avenga/couper/logging"
 	"github.com/hashicorp/hcl/v2"
@@ -122,7 +123,13 @@ func (r *Response) WriteHeader(statusCode int) {
 
 	r.configureHeader()
 	r.applyModifier()
-	r.rw.WriteHeader(statusCode)
+
+	if statusCode == 0 {
+		r.rw.Header().Set(errors.HeaderErrorCode, errors.Server.Error())
+		r.rw.WriteHeader(errors.Server.HTTPStatus())
+	} else {
+		r.rw.WriteHeader(statusCode)
+	}
 	r.statusWritten = true
 	r.statusCode = statusCode
 }


### PR DESCRIPTION
This pull request should fix two rare cases which would lead to possible statusCode 0 writes to the client. A panic thrown by the http package will prevent this. One way could be to read an invalid gzip header and processing further with already read body bytes (gzipheader, 10bytes) which could also lead to content-length != body.len write errors.

a) handle gzip reader creation error, reset backend response body
b) add a fallback to our responseWriter to write at least status 500

---
<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>
