### PR TITLE
Fix endpoint request canceling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Unreleased changes are available as `avenga/couper:edge` container.
   * [Basic Auth](./docs/REFERENCE.md#basic-auth-block) did not work if only the `htpasswd_file` attribute was defined ([#293](https://github.com/avenga/couper/pull/293))
   * Missing error handling for backend gzip header reads ([#291](https://github.com/avenga/couper/pull/291))
   * ResponseWriter fallback for possible statusCode 0 writes ([#291](https://github.com/avenga/couper/pull/291))
+  * Proper client-request canceling ([#294](https://github.com/avenga/couper/pull/294))
 
 * [**Beta**](./docs/BETA.md)
   * OAuth2 Authorization Code Grant Flow: [`beta_oauth2 {}` block](./docs/REFERENCE.md#oauth2-ac-block-beta);  [`beta_oauth_authorization_url()`](./docs/REFERENCE.md#functions) and [`beta_oauth_verifier()`](./docs/REFERENCE.md#functions) ([#247](https://github.com/avenga/couper/pull/247))

--- a/handler/endpoint.go
+++ b/handler/endpoint.go
@@ -62,7 +62,7 @@ func (e *Endpoint) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	var (
 		clientres    *http.Response
 		err          error
-		log          = e.log.WithField("uid", req.Context().Value(request.UID))
+		log          = e.log.WithContext(req.Context())
 		isErrHandler = strings.HasPrefix(e.opts.LogHandlerKind, "error_") // weak ref
 	)
 
@@ -105,7 +105,7 @@ func (e *Endpoint) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	select {
 	case <-req.Context().Done():
 		err = req.Context().Err()
-		*req = *req.WithContext(context.WithValue(req.Context(), request.Error, errors.ClientRequest.With(err)))
+		log.WithError(errors.ClientRequest.With(err)).Error()
 		return
 	default:
 	}

--- a/handler/endpoint.go
+++ b/handler/endpoint.go
@@ -102,6 +102,14 @@ func (e *Endpoint) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	e.readResults(subCtx, proxyResults, beresps)
 	e.readResults(subCtx, requestResults, beresps)
 
+	select {
+	case <-req.Context().Done():
+		err = req.Context().Err()
+		*req = *req.WithContext(context.WithValue(req.Context(), request.Error, errors.ClientRequest.With(err)))
+		return
+	default:
+	}
+
 	evalContext := req.Context().Value(request.ContextType).(*eval.Context)
 	evalContext = evalContext.WithBeresps(beresps.List()...)
 

--- a/logging/access_log.go
+++ b/logging/access_log.go
@@ -29,8 +29,12 @@ type RecorderInfo interface {
 }
 
 func NewAccessLog(c *Config, logger logrus.FieldLogger) *AccessLog {
+	conf := c
+	if conf == nil {
+		conf = DefaultConfig
+	}
 	return &AccessLog{
-		conf:   c,
+		conf:   conf,
 		logger: logger,
 	}
 }


### PR DESCRIPTION
Handle done channel before results processing which would otherwise lead to wrong configuration error due to missing results

Also prevent closing gzip writer close on cancel, related: #291 

Describe your changes!

---
<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>
