### PR TITLE
Fix non working default setup to get started from source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ COPY --from=builder /couper /couper
 COPY public/couper.hcl /conf/
 COPY public/index.html /htdocs/
 WORKDIR /conf
-ENV COUPER_LOG_FORMAT=json
+ENV COUPER_LOG_FORMAT=json \
+    DOC_DIR=/htdocs
 EXPOSE 8080
 USER 1000:1000
 ENTRYPOINT ["/couper"]

--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ Key features are:
 
 The full list of features of Couper 1.0 is [here](FEATURES.md) or at [https://couper.io/features](https://couper.io/features).
 
+## Developers
+
+*Developers* requiring [Go](https://golang.org/) to start with `make build`.
+Couper requires a configuration file. You can start with a simple one and use:
+
+```console
+./couper run -f public/couper.hcl
+```
+
 ## Contributing
 
 Thanks for your interest in contributing.

--- a/couper.code-workspace
+++ b/couper.code-workspace
@@ -22,7 +22,7 @@
 				"request": "launch",
 				"mode": "debug",
 				"program": "${workspaceFolder}/main.go",
-				"args": ["run"]
+				"args": ["run", "-f", "./public/couper.hcl"]
 			},
 		]
 	}

--- a/public/couper.hcl
+++ b/public/couper.hcl
@@ -1,5 +1,11 @@
 server "couper" {
   files {
-    document_root = "/htdocs"
+    document_root = env.DOC_DIR
+  }
+}
+
+defaults {
+  environment_variables = {
+    DOC_DIR = "./"
   }
 }


### PR DESCRIPTION
A new developer or contributor may be lost while building from source.

---
<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>
