### PR TITLE
token request accept header (for Github)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 Unreleased changes are available as `avenga/couper:edge` container.
 
+* **Added**
+  * `Accept: application/json` request header to the OAuth2 token request, in order to make the Github token endpoint respond with a JSON token response ([#307](https://github.com/avenga/couper/pull/307))
+
 * **Changed**
   * Organized log format fields for uniform access and upstream log ([#300](https://github.com/avenga/couper/pull/300))
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -279,6 +279,8 @@ The `oauth2` block in the [Backend Block](#backend-block) context configures the
 | `token_endpoint_auth_method` |string|`client_secret_basic`|Defines the method to authenticate the client at the token endpoint.|If set to `client_secret_post`, the client credentials are transported in the request body. If set to `client_secret_basic`, the client credentials are transported via Basic Authentication.|-|
 | `scope`                      |string|-|  A space separated list of requested scopes for the access token.|-| `scope = "read write"` |
 
+The HTTP header field `Accept: application/json` is automatically added to the token request. This can be modified with [request header modifiers](#request-header) in a [backend block](#backend-block).
+
 ### Websockets Block
 
 The `websockets` block activates support for websocket connections in Couper.
@@ -395,6 +397,8 @@ Like all [Access Control](#access-control) types, the `beta_oauth2` block is def
 
 If the authorization server supports the `code_challenge_method` `S256` (a.k.a. PKCE, see RFC 7636), we recommend `verifier_method = "ccm_s256"`.
 
+The HTTP header field `Accept: application/json` is automatically added to the token request. This can be modified with [request header modifiers](#request-header) in a [backend block](#backend-block).
+
 ### OIDC Block (Beta)
 
 The `beta_oidc` block lets you configure the `beta_oauth_authorization_url()` [function](#functions) and an access
@@ -419,6 +423,8 @@ Like all [Access Control](#access-control) types, the `beta_oidc` block is defin
 | `verifier_value` | string or expression | - | The value of the (unhashed) verifier. | &#9888; required; e.g. using cookie value created with [`beta_oauth_verifier()` function](#functions) | `verifier_value = request.cookies.verifier` |
 
 If the OpenID server supports the `code_challenge_method` `S256` the default value for `verifier_method`is `ccm_s256`, `nonce` otherwise.
+
+The HTTP header field `Accept: application/json` is automatically added to the token request. This can be modified with [request header modifiers](#request-header) in a [backend block](#backend-block).
 
 ### SAML Block
 

--- a/oauth2/client.go
+++ b/oauth2/client.go
@@ -27,6 +27,7 @@ func (c *Client) requestToken(ctx context.Context, requestParams map[string]stri
 		return nil, 0, err
 	}
 
+	tokenReq.Header.Set("Accept", "application/json")
 	tokenRes, err := c.Backend.RoundTrip(tokenReq)
 	if err != nil {
 		return nil, 0, err

--- a/server/http_oauth2_test.go
+++ b/server/http_oauth2_test.go
@@ -29,6 +29,9 @@ func TestEndpoints_OAuth2(t *testing.T) {
 
 		oauthOrigin := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 			if req.URL.Path == "/oauth2" {
+				if accept := req.Header.Get("Accept"); accept != "application/json" {
+					t.Errorf("expected Accept %q, got: %q", "application/json", accept)
+				}
 				if cl := req.Header.Get("Content-Length"); cl != "29" {
 					t.Errorf("Unexpected C/L given: %s", cl)
 				}
@@ -196,6 +199,9 @@ func TestOAuth2_AccessControl(t *testing.T) {
 
 	oauthOrigin := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		if req.URL.Path == "/token" {
+			if accept := req.Header.Get("Accept"); accept != "application/json" {
+				t.Errorf("expected Accept %q, got: %q", "application/json", accept)
+			}
 			_ = req.ParseForm()
 			rw.Header().Set("Content-Type", "application/json")
 			rw.WriteHeader(http.StatusOK)


### PR DESCRIPTION
Github responds to an OAuth2 token request with a JSON format response **only** if the request header `Accept: application/json` is sent.