### PR TITLE
(Re)move additional log fields

### DIFF
--- a/logging/access_log.go
+++ b/logging/access_log.go
@@ -116,7 +116,6 @@ func (log *AccessLog) ServeHTTP(rw http.ResponseWriter, req *http.Request, nextH
 	fields["response"] = responseFields
 
 	if writtenBytes > 0 {
-		fields["bytes"] = writtenBytes
 		responseFields["bytes"] = writtenBytes
 	}
 

--- a/logging/upstream_log.go
+++ b/logging/upstream_log.go
@@ -2,7 +2,6 @@ package logging
 
 import (
 	"crypto/tls"
-	"fmt"
 	"net/http"
 	"net/http/httptrace"
 	"net/url"
@@ -46,9 +45,7 @@ func (u *UpstreamLog) RoundTrip(req *http.Request) (*http.Response, error) {
 		"uid":    req.Context().Value(request.UID),
 		"method": req.Method,
 	}
-	if h, ok := u.next.(fmt.Stringer); ok {
-		fields["handler"] = h.String()
-	}
+
 	if u.config.TypeFieldKey != "" {
 		fields["type"] = u.config.TypeFieldKey
 	}
@@ -81,7 +78,7 @@ func (u *UpstreamLog) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	if req.Host != "" {
 		requestFields["origin"] = req.Host
-		requestFields["host"], fields["port"] = splitHostPort(req.Host)
+		requestFields["host"], requestFields["port"] = splitHostPort(req.Host)
 		if fields["port"] == "" {
 			delete(fields, "port")
 		}

--- a/logging/upstream_log_test.go
+++ b/logging/upstream_log_test.go
@@ -85,8 +85,8 @@ func TestUpstreamLog_RoundTrip(t *testing.T) {
 					"host":   "localhost",
 					"origin": "localhost:8080",
 					"path":   "/",
+					"port":   "8080",
 				},
-				"port": "8080",
 			},
 		},
 		{
@@ -121,12 +121,12 @@ func TestUpstreamLog_RoundTrip(t *testing.T) {
 					"path":   "/test",
 					"method": http.MethodGet,
 					"proto":  "http",
+					"port":   "8080",
 				},
 				"response": logrus.Fields{
 					"status": 200,
 				},
 				"method": http.MethodGet,
-				"port":   "8080",
 				"uid":    nil,
 				"status": 200,
 			},

--- a/server/http_integration_test.go
+++ b/server/http_integration_test.go
@@ -1029,7 +1029,8 @@ func TestHTTPServer_LogFields(t *testing.T) {
 	if e, ok := accessLog.Data["endpoint"]; !ok || e != "/" {
 		t.Fatalf("Unexpected endpoint: %s", e)
 	}
-	if b, ok := accessLog.Data["bytes"]; !ok || b != len(resBytes) {
+
+	if b, ok := accessLog.Data["response"].(logging.Fields)["bytes"]; !ok || b != len(resBytes) {
 		t.Fatalf("Unexpected number of bytes: %d\npayload: %s", b, string(resBytes))
 	}
 }

--- a/server/http_integration_test.go
+++ b/server/http_integration_test.go
@@ -3198,7 +3198,7 @@ func TestEndpoint_Response(t *testing.T) {
 			}
 
 			if len(resBytes) > 0 {
-				b, exist := logHook.LastEntry().Data["bytes"]
+				b, exist := logHook.LastEntry().Data["response"].(logging.Fields)["bytes"]
 				if !exist || b != len(resBytes) {
 					t.Errorf("Want bytes log: %d\ngot:\t%v", len(resBytes), logHook.LastEntry())
 				}


### PR DESCRIPTION
Removed access_log.go.fields["bytes"] and upstream_log.go.fields["handler"], altered upstream_log.go.fields["port"] -> upstream_log.go.requestFields["port"]

---
<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>
