### PR TITLE
Use jwt block for signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Unreleased changes are available as `avenga/couper:edge` container.
 
 * **Added**
   * `Accept: application/json` request header to the OAuth2 token request, in order to make the Github token endpoint respond with a JSON token response ([#307](https://github.com/avenga/couper/pull/307))
+  * `signing_ttl` and `signing_key`/`signing_key_file` to [`jwt` block](./docs/REFERENCE.md#jwt-block) for use with [`jwt_sign()` function](#functions) ([#309](https://github.com/avenga/couper/pull/309))
 
 * **Changed**
   * Organized log format fields for uniform access and upstream log ([#300](https://github.com/avenga/couper/pull/300))

--- a/accesscontrol/jwt/algorithm.go
+++ b/accesscontrol/jwt/algorithm.go
@@ -1,4 +1,8 @@
-package accesscontrol
+package jwt
+
+type (
+	Algorithm int
+)
 
 const (
 	AlgorithmUnknown Algorithm = iota - 1

--- a/accesscontrol/jwt_test.go
+++ b/accesscontrol/jwt_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/dgrijalva/jwt-go/v4"
 
 	ac "github.com/avenga/couper/accesscontrol"
+	acjwt "github.com/avenga/couper/accesscontrol/jwt"
 	"github.com/avenga/couper/config/reader"
 	"github.com/avenga/couper/config/request"
 	"github.com/avenga/couper/errors"
@@ -134,7 +135,7 @@ QolLGgj3tz4NbDEitq+zKMr0uTHvP1Vyu1mXAflcpYcJA4ZmuB3Oj39e0U0gnmr/
 
 func Test_JWT_Validate(t *testing.T) {
 	type fields struct {
-		algorithm      ac.Algorithm
+		algorithm      acjwt.Algorithm
 		claims         map[string]interface{}
 		claimsRequired []string
 		source         ac.JWTSource
@@ -155,7 +156,7 @@ func Test_JWT_Validate(t *testing.T) {
 		var token string
 		var tokenErr error
 
-		algo := ac.NewAlgorithm(signingMethod.Alg())
+		algo := acjwt.NewAlgorithm(signingMethod.Alg())
 
 		if algo.IsHMAC() {
 			pubKeyBytes = []byte("mySecretK3y")

--- a/config/ac_jwt.go
+++ b/config/ac_jwt.go
@@ -23,6 +23,9 @@ type JWT struct {
 	PostParam          string   `hcl:"post_param,optional"`
 	QueryParam         string   `hcl:"query_param,optional"`
 	SignatureAlgorithm string   `hcl:"signature_algorithm"`
+	SigningKey         string   `hcl:"signing_key,optional"`
+	SigningKeyFile     string   `hcl:"signing_key_file,optional"`
+	SigningTTL         string   `hcl:"signing_ttl,optional"`
 
 	// Internally used for 'error_handler'.
 	Remain hcl.Body `hcl:",remain"`

--- a/config/configload/load.go
+++ b/config/configload/load.go
@@ -293,7 +293,11 @@ func LoadConfig(body hcl.Body, src []byte, filename string) (*config.Couper, err
 
 	jwtSigningConfigs := make([]*lib.JWTSigningConfig, 0)
 	for _, profile := range couperConfig.Definitions.JWTSigningProfile {
-		jwtSigningConfigs = append(jwtSigningConfigs, lib.NewJWTSigningConfigFromJWTSigningProfile(profile))
+		config, err := lib.NewJWTSigningConfigFromJWTSigningProfile(profile)
+		if err != nil {
+			return nil, errors.Configuration.Label(profile.Name).With(err)
+		}
+		jwtSigningConfigs = append(jwtSigningConfigs, config)
 	}
 
 	couperConfig.Context = evalContext.

--- a/config/configload/load.go
+++ b/config/configload/load.go
@@ -19,6 +19,7 @@ import (
 	"github.com/avenga/couper/config/reader"
 	"github.com/avenga/couper/errors"
 	"github.com/avenga/couper/eval"
+	"github.com/avenga/couper/eval/lib"
 )
 
 const (
@@ -290,8 +291,13 @@ func LoadConfig(body hcl.Body, src []byte, filename string) (*config.Couper, err
 		saml.MetadataBytes = metadata
 	}
 
+	jwtSigningConfigs := make([]*lib.JWTSigningConfig, 0)
+	for _, profile := range couperConfig.Definitions.JWTSigningProfile {
+		jwtSigningConfigs = append(jwtSigningConfigs, lib.NewJWTSigningConfigFromJWTSigningProfile(profile))
+	}
+
 	couperConfig.Context = evalContext.
-		WithJWTProfiles(couperConfig.Definitions.JWTSigningProfile).
+		WithJWTSigningConfigs(jwtSigningConfigs).
 		WithOAuth2AC(couperConfig.Definitions.OAuth2AC).
 		WithSAML(couperConfig.Definitions.SAML)
 

--- a/config/configload/load.go
+++ b/config/configload/load.go
@@ -299,6 +299,15 @@ func LoadConfig(body hcl.Body, src []byte, filename string) (*config.Couper, err
 		}
 		jwtSigningConfigs = append(jwtSigningConfigs, config)
 	}
+	for _, jwt := range couperConfig.Definitions.JWT {
+		config, err := lib.NewJWTSigningConfigFromJWT(jwt)
+		if err != nil {
+			return nil, errors.Configuration.Label(jwt.Name).With(err)
+		}
+		if config != nil {
+			jwtSigningConfigs = append(jwtSigningConfigs, config)
+		}
+	}
 
 	couperConfig.Context = evalContext.
 		WithJWTSigningConfigs(jwtSigningConfigs).

--- a/config/configload/load.go
+++ b/config/configload/load.go
@@ -293,6 +293,9 @@ func LoadConfig(body hcl.Body, src []byte, filename string) (*config.Couper, err
 
 	jwtSigningConfigs := make(map[string]*lib.JWTSigningConfig, 0)
 	for _, profile := range couperConfig.Definitions.JWTSigningProfile {
+		if _, exists := jwtSigningConfigs[profile.Name]; exists {
+			return nil, errors.Configuration.Messagef("jwt_signing_profile block with label %s already defined", profile.Name)
+		}
 		config, err := lib.NewJWTSigningConfigFromJWTSigningProfile(profile)
 		if err != nil {
 			return nil, errors.Configuration.Label(profile.Name).With(err)

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -358,7 +358,7 @@ The `jwt` block may also be referenced by the [`jwt_sign()` function](#functions
 | :-------- | :--------------- | :--------------- | :--------------- | :--------------- | :--------------- |
 | `signing_key`       |string|-|Private key (in PEM format) for `RS*` variants.|-|-|
 | `signing_key_file`  |string|-|Optional file reference instead of `signing_key` usage.|-|-|
-| `signing_ttl`       |string|-|The token's time-to-live (creates the `exp` claim).|-|-|
+| `signing_ttl`       |duration|-|The token's time-to-live (creates the `exp` claim).|-|-|
 
 ### JWT Signing Profile Block
 
@@ -378,7 +378,7 @@ An example can be found
 | `key`  |string|-|Private key (in PEM format) for `RS*` variants or the secret for `HS*` algorithm.|-|-|
 | `key_file`  |string|-|Optional file reference instead of `key` usage.|-|-|
 | `signature_algorithm`|-|-|-|&#9888; required. Valid values are: `RS256` `RS384` `RS512` `HS256` `HS384` `HS512`.|-|
-|`ttl`  |string|-|The token's time-to-live (creates the `exp` claim).|-|-|
+|`ttl`  |duration|-|The token's time-to-live (creates the `exp` claim).|-|-|
 | `claims` |string|-|Default claims for the JWT payload.|-|-|
 
 ### OAuth2 AC Block (Beta)

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -352,6 +352,8 @@ required _label_.
 
 The `jwt` block may also be referenced by the [`jwt_sign()` function](#functions), if it has a `signing_ttl` defined. For `HS*` algorithms the signing key is taken from `key`/`key_file`, for `RS*` algorithms, `signing_key` or `signing_key_file` have to be specified.
 
+*Note:* A `jwt` block with `signing_ttl` cannot have the same label as a `jwt_signing_profile` block.
+
 | Attribute(s) | Type |Default|Description|Characteristic(s)| Example|
 | :-------- | :--------------- | :--------------- | :--------------- | :--------------- | :--------------- |
 | `signing_key`       |string|-|Private key (in PEM format) for `RS*` variants.|-|-|

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -358,7 +358,7 @@ The `jwt` block may also be referenced by the [`jwt_sign()` function](#functions
 | :-------- | :--------------- | :--------------- | :--------------- | :--------------- | :--------------- |
 | `signing_key`       |string|-|Private key (in PEM format) for `RS*` variants.|-|-|
 | `signing_key_file`  |string|-|Optional file reference instead of `signing_key` usage.|-|-|
-| `signing_ttl`       |duration|-|The token's time-to-live (creates the `exp` claim).|-|-|
+| `signing_ttl`       |[duration](#duration)|-|The token's time-to-live (creates the `exp` claim).|-|-|
 
 ### JWT Signing Profile Block
 
@@ -378,7 +378,7 @@ An example can be found
 | `key`  |string|-|Private key (in PEM format) for `RS*` variants or the secret for `HS*` algorithm.|-|-|
 | `key_file`  |string|-|Optional file reference instead of `key` usage.|-|-|
 | `signature_algorithm`|-|-|-|&#9888; required. Valid values are: `RS256` `RS384` `RS512` `HS256` `HS384` `HS512`.|-|
-|`ttl`  |duration|-|The token's time-to-live (creates the `exp` claim).|-|-|
+|`ttl`  |[duration](#duration)|-|The token's time-to-live (creates the `exp` claim).|-|-|
 | `claims` |string|-|Default claims for the JWT payload.|-|-|
 
 ### OAuth2 AC Block (Beta)
@@ -423,7 +423,7 @@ Like all [Access Control](#access-control) types, the `beta_oidc` block is defin
 | :------------------------------ | :--------------- | :--------------- | :--------------- | :--------------- | :--------------- |
 | `backend`                       |string|-|[Backend Block Reference](#backend-block)| &#9888; Do not disable the peer certificate validation with `disable_certificate_validation = true`! |-|
 | `configuration_url` | string |-| The OpenID configuration URL. |&#9888; required|-|
-| `configuration_ttl` | duration | `1h` | The duration to cache the OpenID configuration located at `configuration_url`. | - | `configuration_ttl = "1d"` |
+| `configuration_ttl` | [duration](#duration) | `1h` | The duration to cache the OpenID configuration located at `configuration_url`. | - | `configuration_ttl = "1d"` |
 | `token_endpoint_auth_method` |string|`client_secret_basic`|Defines the method to authenticate the client at the token endpoint.|If set to `client_secret_post`, the client credentials are transported in the request body. If set to `client_secret_basic`, the client credentials are transported via Basic Authentication.|-|
 | `redirect_uri` | string |-| The Couper endpoint for receiving the authorization code. |&#9888; required. Relative URL references are resolved against the origin of the current request URL.|-|
 | `client_id`|  string|-|The client identifier.|&#9888; required|-|

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -346,9 +346,17 @@ required _label_.
 | `header`          |string|-|-|&#9888; Implies `Bearer` if `Authorization` (case-insensitive) is used, otherwise any other header name can be used.|`header = "Authorization"` |
 | `key`           |string|-|Public key (in PEM format) for `RS*` variants or the secret for `HS*` algorithm.|-|-|
 | `key_file`          |string|-|Optional file reference instead of `key` usage.|-|-|
-|  `signature_algorithm`           |string|-|-|&#9888; required. Valid values are: `RS256` `RS384` `RS512` `HS256` `HS384` `HS512`.|-|
+| `signature_algorithm`           |string|-|-|&#9888; required. Valid values are: `RS256` `RS384` `RS512` `HS256` `HS384` `HS512`.|-|
 | `claims`               |string|-|Equals/in comparison with JWT payload.|-|-|
 | `required_claims`      | string|-|list of claims that must be given for a valid token |-|-|
+
+The `jwt` block may also be referenced by the [`jwt_sign()` function](#functions), if it has a `signing_ttl` defined. For `HS*` algorithms the signing key is taken from `key`/`key_file`, for `RS*` algorithms, `signing_key` or `signing_key_file` have to be specified.
+
+| Attribute(s) | Type |Default|Description|Characteristic(s)| Example|
+| :-------- | :--------------- | :--------------- | :--------------- | :--------------- | :--------------- |
+| `signing_key`       |string|-|Private key (in PEM format) for `RS*` variants.|-|-|
+| `signing_key_file`  |string|-|Optional file reference instead of `signing_key` usage.|-|-|
+| `signing_ttl`       |string|-|The token's time-to-live (creates the `exp` claim).|-|-|
 
 ### JWT Signing Profile Block
 
@@ -636,7 +644,7 @@ To access the HTTP status code of the `default` response use `backend_responses.
 | `coalesce`                     |                 | Returns the first of the given arguments that is not null.                                                                                                                                                                                                                                           | `arg...` (various)                  | `coalesce(request.cookies.foo, "bar")`               |
 | `json_decode`                  | various         | Parses the given JSON string and, if it is valid, returns the value it represents.                                                                                                                                                                                                                   | `encoded` (string)                  | `json_decode("{\"foo\": 1}")`                        |
 | `json_encode`                  | string          | Returns a JSON serialization of the given value.                                                                                                                                                                                                                                                     | `val` (various)                     | `json_encode(request.context.myJWT)`                 |
-| `jwt_sign`                     | string          | jwt_sign creates and signs a JSON Web Token (JWT) from information from a referenced [JWT Signing Profile Block](#jwt-signing-profile-block) and additional claims provided as a function parameter.                                                                                                 | `label` (string), `claims` (object) | `jwt_sign("myJWT")`                                  |
+| `jwt_sign`                     | string          | jwt_sign creates and signs a JSON Web Token (JWT) from information from a referenced [JWT Signing Profile Block](#jwt-signing-profile-block) (or [JWT Block](#jwt-block) with `signing_ttl`) and additional claims provided as a function parameter.                                                                                                 | `label` (string), `claims` (object) | `jwt_sign("myJWT")`                                  |
 | `merge`                        | object or tuple | Deep-merges two or more of either objects or tuples. `null` arguments are ignored. A `null` attribute value in an object removes the previous attribute value. An attribute value with a different type than the current value is set as the new value. `merge()` with no parameters returns `null`. | `arg...` (object or tuple)          | `merge(request.headers, { x-additional = "myval" })` |
 | `beta_oauth_authorization_url` | string          | Creates an OAuth2 authorization URL from a referenced [OAuth2 AC Block](#oauth2-ac-block-beta) or [OIDC Block](#oidc-block-beta).                                                                                                                                                                                                      | `label` (string)                    | `beta_oauth_authorization_url("myOAuth2")`           |
 | `beta_oauth_verifier`          | string          | Creates a cryptographically random key as specified in RFC 7636, applicable for all verifier methods; e.g. to be set as a cookie and read into `verifier_value`. Multiple calls of this function in the same client request context return the same value.                                           |                                     | `beta_oauth_verifier()`                         |

--- a/eval/context.go
+++ b/eval/context.go
@@ -45,7 +45,7 @@ type Context struct {
 	inner             context.Context
 	memorize          map[string]interface{}
 	oauth2            []config.OAuth2Authorization
-	jwtSigningConfigs []*lib.JWTSigningConfig
+	jwtSigningConfigs map[string]*lib.JWTSigningConfig
 	saml              []*config.SAML
 }
 
@@ -99,7 +99,7 @@ func (c *Context) WithClientRequest(req *http.Request) *Context {
 		inner:             c.inner,
 		memorize:          make(map[string]interface{}),
 		oauth2:            c.oauth2[:],
-		jwtSigningConfigs: c.jwtSigningConfigs[:],
+		jwtSigningConfigs: c.jwtSigningConfigs,
 		saml:              c.saml[:],
 	}
 
@@ -163,7 +163,7 @@ func (c *Context) WithBeresps(beresps ...*http.Response) *Context {
 		inner:             c.inner,
 		memorize:          c.memorize,
 		oauth2:            c.oauth2[:],
-		jwtSigningConfigs: c.jwtSigningConfigs[:],
+		jwtSigningConfigs: c.jwtSigningConfigs,
 		saml:              c.saml[:],
 	}
 	ctx.inner = context.WithValue(c.inner, request.ContextType, ctx)
@@ -231,10 +231,10 @@ func (c *Context) WithBeresps(beresps ...*http.Response) *Context {
 }
 
 // WithJWTSigningConfigs initially sets up the lib.FnJWTSign function.
-func (c *Context) WithJWTSigningConfigs(configs []*lib.JWTSigningConfig) *Context {
+func (c *Context) WithJWTSigningConfigs(configs map[string]*lib.JWTSigningConfig) *Context {
 	c.jwtSigningConfigs = configs
 	if c.jwtSigningConfigs == nil {
-		c.jwtSigningConfigs = make([]*lib.JWTSigningConfig, 0)
+		c.jwtSigningConfigs = make(map[string]*lib.JWTSigningConfig, 0)
 	}
 	c.updateFunctions()
 	return c

--- a/eval/lib/jwt.go
+++ b/eval/lib/jwt.go
@@ -129,12 +129,7 @@ func NewJWTSigningConfigFromJWT(j *config.JWT) (*JWTSigningConfig, error) {
 	return c, nil
 }
 
-func NewJwtSignFunction(jwtSigningConfigs []*JWTSigningConfig, confCtx *hcl.EvalContext) function.Function {
-	signingConfigs := make(map[string]*JWTSigningConfig)
-	for _, jsc := range jwtSigningConfigs {
-		signingConfigs[jsc.Name] = jsc
-	}
-
+func NewJwtSignFunction(jwtSigningConfigs map[string]*JWTSigningConfig, confCtx *hcl.EvalContext) function.Function {
 	return function.New(&function.Spec{
 		Params: []function.Parameter{
 			{
@@ -148,12 +143,12 @@ func NewJwtSignFunction(jwtSigningConfigs []*JWTSigningConfig, confCtx *hcl.Eval
 		},
 		Type: function.StaticReturnType(cty.String),
 		Impl: func(args []cty.Value, _ cty.Type) (ret cty.Value, err error) {
-			if len(signingConfigs) == 0 {
+			if len(jwtSigningConfigs) == 0 {
 				return cty.StringVal(""), fmt.Errorf("missing jwt_signing_profile or jwt definitions")
 			}
 
 			label := args[0].AsString()
-			signingConfig := signingConfigs[label]
+			signingConfig := jwtSigningConfigs[label]
 			if signingConfig == nil {
 				return cty.StringVal(""), fmt.Errorf("missing jwt_signing_profile or jwt for given label: %s", label)
 			}

--- a/eval/lib/jwt.go
+++ b/eval/lib/jwt.go
@@ -13,6 +13,7 @@ import (
 	"github.com/zclconf/go-cty/cty/function"
 	"github.com/zclconf/go-cty/cty/function/stdlib"
 
+	acjwt "github.com/avenga/couper/accesscontrol/jwt"
 	"github.com/avenga/couper/config"
 	"github.com/avenga/couper/internal/seetie"
 )
@@ -29,7 +30,11 @@ type JWTSigningConfig struct {
 	TTL                string
 }
 
-func NewJWTSigningConfigFromJWTSigningProfile(j *config.JWTSigningProfile) *JWTSigningConfig {
+func NewJWTSigningConfigFromJWTSigningProfile(j *config.JWTSigningProfile) (*JWTSigningConfig, error) {
+	if alg := acjwt.NewAlgorithm(j.SignatureAlgorithm); alg == acjwt.AlgorithmUnknown {
+		return nil, fmt.Errorf("algorithm is not supported")
+	}
+
 	c := &JWTSigningConfig{
 		Claims:             j.Claims,
 		KeyBytes:           j.KeyBytes,
@@ -37,7 +42,7 @@ func NewJWTSigningConfigFromJWTSigningProfile(j *config.JWTSigningProfile) *JWTS
 		SignatureAlgorithm: j.SignatureAlgorithm,
 		TTL:                j.TTL,
 	}
-	return c
+	return c, nil
 }
 
 func NewJwtSignFunction(jwtSigningConfigs []*JWTSigningConfig, confCtx *hcl.EvalContext) function.Function {

--- a/eval/lib/jwt.go
+++ b/eval/lib/jwt.go
@@ -98,9 +98,7 @@ func NewJWTSigningConfigFromJWT(j *config.JWT) (*JWTSigningConfig, error) {
 		return nil, err
 	}
 
-	var (
-		signingKey, signingKeyFile string
-	)
+	var signingKey, signingKeyFile string
 
 	if alg.IsHMAC() {
 		signingKey = j.Key

--- a/eval/lib/jwt_test.go
+++ b/eval/lib/jwt_test.go
@@ -329,6 +329,106 @@ BShcGHZl9nzWDtEZzgdX7cbG5nRUo1+whzBQdYoQmg==
 			`{"sub":"12345"}`,
 			"eyJhbGciOiJSUzUxMiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJUSEVfQVVESUVOQ0UiLCJpc3MiOiJ0aGVfaXNzdWVyIiwic3ViIjoiMTIzNDUifQ.flU1adXUEaZuqkFwhcgJ8U3OXYOTC6RQCWw9rb7nkTNzt7XrU13EPtlxH5_7lpAvyBn4iyOCiJd19y1paupyeYbHEgUGsVXa4Iu1jQ8I7C41ejLNybdg7XpRzf3zt6tMC3W9Bp0TYRqrykTiQ0W4pg0sGJCV-e30dSDgkfuS_TM",
 		},
+		{
+			"jwt / HS256 / key",
+			`
+			server "test" {
+			}
+			definitions {
+				jwt "MySelfSignedToken" {
+					signature_algorithm = "HS256"
+					key = "$3cRe4"
+					signing_ttl = "0"
+					claims = {
+					  iss = to_lower("The_Issuer")
+					  aud = to_upper("The_Audience")
+					}
+				}
+			}
+			`,
+			"MySelfSignedToken",
+			`{"sub":"12345"}`,
+			"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJUSEVfQVVESUVOQ0UiLCJpc3MiOiJ0aGVfaXNzdWVyIiwic3ViIjoiMTIzNDUifQ.Hf-ZtIlsxR2bDOdAEMaDHaOBmfVWTQi9U68yV4YHW9w",
+		},
+		{
+			"jwt / HS256 / key_file",
+			`
+			server "test" {
+			}
+			definitions {
+				jwt "MySelfSignedToken" {
+					signature_algorithm = "HS256"
+					key_file = "testdata/secret.txt"
+					signing_ttl = "0"
+					claims = {
+					  iss = to_lower("The_Issuer")
+					  aud = to_upper("The_Audience")
+					}
+				}
+			}
+			`,
+			"MySelfSignedToken",
+			`{"sub":"12345"}`,
+			"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJUSEVfQVVESUVOQ0UiLCJpc3MiOiJ0aGVfaXNzdWVyIiwic3ViIjoiMTIzNDUifQ.Hf-ZtIlsxR2bDOdAEMaDHaOBmfVWTQi9U68yV4YHW9w",
+		},
+		{
+			"jwt / RS256 / key",
+			`
+			server "test" {
+			}
+			definitions {
+				jwt "MySelfSignedToken" {
+					signature_algorithm = "RS256"
+					signing_key = <<EOF
+-----BEGIN RSA PRIVATE KEY-----
+MIICWwIBAAKBgQDGSd+sSTss2uOuVJKpumpFAamlt1CWLMTAZNAabF71Ur0P6u83
+3RhAIjXDSA/QeVitzvqvCZpNtbOJVegaREqLMJqvFOUkFdLNRP3f9XjYFFvubo09
+tcjX6oGEREKDqLG2MfZ2Z8LVzuJc6SwZMgVFk/63rdAOci3W9u3zOSGj4QIDAQAB
+AoGAMzI1rw0FW1J0wLkTWQFJmOGSBLhs9Sk/75DX7kqWxe6D5A07kIfkUALFMNN1
+SdVa4R10uibXkULdxRLKJ6YEPLGAN3UmdbnBGxZ+fHAKY3PxM5lL9d7ET08A0u/8
+6vB+GZ8w0eqsp4EFzmXI5LS63cRo9GA5iliGpKWtd2IUA2UCQQDnZHJTHW21vrXv
+GqXoPxOoQAflxvnHYDgNQcRJxlEokFmSK405n7G2//NrsSnXYmUsA/wdh9YsAYZ3
+4xy6hKE3AkEA22Aw58FnypcRAKBTqEWHv957szAmz9R6mLJqG7283YWXL0VGDOuR
+qdC4QjMrix3O8WbJxGNaVCrvYKVtKEfPpwJAGGWw4C6UKLuI90L6BzjPW8gUjRej
+sm/kuREcHyM3320I5K6O32qFFGR8R/iQDtOjEzcAWCTAYjdu9CkQGGJvlQJAHpCR
+X8jfmCdiFA9CeKBvYHk0DOw5jB1Tk3DQPds6tDaHsOta7jPoEJvnADo25+QYUCP9
+GqKpFC8DORjzU3hl4wJACEzmqzAco2M4mVc+PxPX0b3LHaREyXURd+faFXUecxSF
+BShcGHZl9nzWDtEZzgdX7cbG5nRUo1+whzBQdYoQmg==
+-----END RSA PRIVATE KEY-----
+					EOF
+					signing_ttl = "0"
+					claims = {
+					  iss = to_lower("The_Issuer")
+					  aud = to_upper("The_Audience")
+					}
+				}
+			}
+			`,
+			"MySelfSignedToken",
+			`{"sub":"12345"}`,
+			"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJUSEVfQVVESUVOQ0UiLCJpc3MiOiJ0aGVfaXNzdWVyIiwic3ViIjoiMTIzNDUifQ.oSS8rC1KonyZ-JZTZhkqZb5bN0_2Lrbl4J33nLgWroc5vDvmLW0KnX0RQfXy0OjX4uBBYTThActqqqM6vidaXmBfsQ77uB9narWeAptRnKqEPlY-onTHDmTMCz7vQ9wbLT7Aa6MYlhRqKX5adpPPbwBUuhm2I-yMF80nSmFpSk0",
+		},
+		{
+			"jwt / RS256 / key_file",
+			`
+			server "test" {
+			}
+			definitions {
+				jwt "MySelfSignedToken" {
+					signature_algorithm = "RS256"
+					signing_key_file = "testdata/rsa_priv.pem"
+					signing_ttl = "0"
+					claims = {
+					  iss = to_lower("The_Issuer")
+					  aud = to_upper("The_Audience")
+					}
+				}
+			}
+			`,
+			"MySelfSignedToken",
+			`{"sub":"12345"}`,
+			"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJUSEVfQVVESUVOQ0UiLCJpc3MiOiJ0aGVfaXNzdWVyIiwic3ViIjoiMTIzNDUifQ.oSS8rC1KonyZ-JZTZhkqZb5bN0_2Lrbl4J33nLgWroc5vDvmLW0KnX0RQfXy0OjX4uBBYTThActqqqM6vidaXmBfsQ77uB9narWeAptRnKqEPlY-onTHDmTMCz7vQ9wbLT7Aa6MYlhRqKX5adpPPbwBUuhm2I-yMF80nSmFpSk0",
+		},
 	}
 
 	for _, tt := range tests {
@@ -498,6 +598,39 @@ func TestJwtSignConfigError(t *testing.T) {
 			`{"sub": "12345"}`,
 			"configuration error: MyToken: algorithm is not supported",
 		},
+		{
+			"missing signing key or key_file",
+			`
+			server "test" {
+			}
+			definitions {
+				jwt_signing_profile "MyToken" {
+					signature_algorithm = "RS256"
+					ttl = "0"
+				}
+			}
+			`,
+			"MyToken",
+			`{"sub": "12345"}`,
+			"configuration error: MyToken: jwt_signing_profile key: read error: required: configured attribute or file",
+		},
+		{
+			"jwt / missing signing key or key_file",
+			`
+			server "test" {
+			}
+			definitions {
+				jwt "MySelfSignedToken" {
+					signature_algorithm = "RS256"
+					key_file = "testdata/rsa_priv.pem"
+					signing_ttl = "0"
+				}
+			}
+			`,
+			"MySelfSignedToken",
+			`{"sub": "12345"}`,
+			"configuration error: MySelfSignedToken: jwt signing key: read error: required: configured attribute or file",
+		},
 	}
 
 	for _, tt := range tests {
@@ -535,10 +668,20 @@ func TestJwtSignError(t *testing.T) {
 					}
 				}
 			}
+			definitions {
+				jwt "MyToken" {
+					signature_algorithm = "HS256"
+					key = "$3cRe4"
+					claims = {
+					  iss = to_lower("The_Issuer")
+					  aud = to_upper("The_Audience")
+					}
+				}
+			}
 			`,
 			"MyToken",
 			`{"sub": "12345"}`,
-			"missing jwt_signing_profile definitions",
+			"missing jwt_signing_profile or jwt definitions",
 		},
 		{
 			"invalid PEM key format",
@@ -576,7 +719,7 @@ func TestJwtSignError(t *testing.T) {
 			`,
 			"NoProfileForThisLabel",
 			`{"sub":"12345"}`,
-			"missing jwt_signing_profile for given label: NoProfileForThisLabel",
+			"missing jwt_signing_profile or jwt for given label: NoProfileForThisLabel",
 		},
 		{
 			"Invalid ttl value",
@@ -611,6 +754,44 @@ func TestJwtSignError(t *testing.T) {
 			"MyToken",
 			`"no object"`,
 			"json: cannot unmarshal string into Go value of type map[string]interface {}",
+		},
+		{
+			"jwt / No profile for label",
+			`
+			server "test" {
+			}
+			definitions {
+				jwt "MySelfSignedToken" {
+					signature_algorithm = "HS256"
+					key = "$3cRe4"
+					signing_ttl = "0"
+					claims = {
+					  iss = to_lower("The_Issuer")
+					  aud = to_upper("The_Audience")
+					}
+				}
+			}
+			`,
+			"NoProfileForThisLabel",
+			`{"sub":"12345"}`,
+			"missing jwt_signing_profile or jwt for given label: NoProfileForThisLabel",
+		},
+		{
+			"jwt / Invalid signing_ttl value",
+			`
+			server "test" {
+			}
+			definitions {
+				jwt "MySelfSignedToken" {
+					signature_algorithm = "HS256"
+					key = "$3cRe4"
+					signing_ttl = "invalid"
+				}
+			}
+			`,
+			"MySelfSignedToken",
+			`{"sub": "12345"}`,
+			"time: invalid duration ",
 		},
 	}
 

--- a/eval/lib/jwt_test.go
+++ b/eval/lib/jwt_test.go
@@ -615,6 +615,23 @@ func TestJwtSignConfigError(t *testing.T) {
 			"configuration error: MyToken: jwt_signing_profile key: read error: required: configured attribute or file",
 		},
 		{
+			"Invalid ttl value",
+			`
+			server "test" {
+			}
+			definitions {
+				jwt_signing_profile "MyToken" {
+					signature_algorithm = "HS256"
+					key = "$3cRe4"
+					ttl = "invalid"
+				}
+			}
+			`,
+			"MyToken",
+			`{"sub": "12345"}`,
+			"configuration error: MyToken: time: invalid duration \"invalid\"",
+		},
+		{
 			"jwt / missing signing key or key_file",
 			`
 			server "test" {
@@ -630,6 +647,23 @@ func TestJwtSignConfigError(t *testing.T) {
 			"MySelfSignedToken",
 			`{"sub": "12345"}`,
 			"configuration error: MySelfSignedToken: jwt signing key: read error: required: configured attribute or file",
+		},
+		{
+			"jwt / Invalid signing_ttl value",
+			`
+			server "test" {
+			}
+			definitions {
+				jwt "MySelfSignedToken" {
+					signature_algorithm = "HS256"
+					signing_key = "$3cRe4"
+					signing_ttl = "invalid"
+				}
+			}
+			`,
+			"MySelfSignedToken",
+			`{"sub": "12345"}`,
+			"configuration error: MySelfSignedToken: time: invalid duration \"invalid\"",
 		},
 	}
 
@@ -722,23 +756,6 @@ func TestJwtSignError(t *testing.T) {
 			"missing jwt_signing_profile or jwt for given label: NoProfileForThisLabel",
 		},
 		{
-			"Invalid ttl value",
-			`
-			server "test" {
-			}
-			definitions {
-				jwt_signing_profile "MyToken" {
-					signature_algorithm = "HS256"
-					key = "$3cRe4"
-					ttl = "invalid"
-				}
-			}
-			`,
-			"MyToken",
-			`{"sub": "12345"}`,
-			"time: invalid duration ",
-		},
-		{
 			"argument claims no object",
 			`
 			server "test" {
@@ -775,23 +792,6 @@ func TestJwtSignError(t *testing.T) {
 			"NoProfileForThisLabel",
 			`{"sub":"12345"}`,
 			"missing jwt_signing_profile or jwt for given label: NoProfileForThisLabel",
-		},
-		{
-			"jwt / Invalid signing_ttl value",
-			`
-			server "test" {
-			}
-			definitions {
-				jwt "MySelfSignedToken" {
-					signature_algorithm = "HS256"
-					key = "$3cRe4"
-					signing_ttl = "invalid"
-				}
-			}
-			`,
-			"MySelfSignedToken",
-			`{"sub": "12345"}`,
-			"time: invalid duration ",
 		},
 	}
 

--- a/eval/lib/jwt_test.go
+++ b/eval/lib/jwt_test.go
@@ -632,6 +632,23 @@ func TestJwtSignConfigError(t *testing.T) {
 			"configuration error: MyToken: time: invalid duration \"invalid\"",
 		},
 		{
+			"invalid PEM key format",
+			`
+			server "test" {
+			}
+			definitions {
+				jwt_signing_profile "MyToken" {
+					signature_algorithm = "RS256"
+					key = "invalid"
+					ttl = 0
+				}
+			}
+			`,
+			"MyToken",
+			`{"sub": "12345"}`,
+			"configuration error: MyToken: invalid Key: Key must be PEM encoded PKCS1 or PKCS8 private key",
+		},
+		{
 			"jwt / missing signing key or key_file",
 			`
 			server "test" {
@@ -664,6 +681,23 @@ func TestJwtSignConfigError(t *testing.T) {
 			"MySelfSignedToken",
 			`{"sub": "12345"}`,
 			"configuration error: MySelfSignedToken: time: invalid duration \"invalid\"",
+		},
+		{
+			"jwt / invalid PEM key format",
+			`
+			server "test" {
+			}
+			definitions {
+				jwt "MySelfSignedToken" {
+					signature_algorithm = "RS256"
+					signing_key = "invalid"
+					signing_ttl = "0"
+				}
+			}
+			`,
+			"MySelfSignedToken",
+			`{"sub": "12345"}`,
+			"configuration error: MySelfSignedToken: invalid Key: Key must be PEM encoded PKCS1 or PKCS8 private key",
 		},
 	}
 
@@ -716,23 +750,6 @@ func TestJwtSignError(t *testing.T) {
 			"MyToken",
 			`{"sub": "12345"}`,
 			"missing jwt_signing_profile or jwt definitions",
-		},
-		{
-			"invalid PEM key format",
-			`
-			server "test" {
-			}
-			definitions {
-				jwt_signing_profile "MyToken" {
-					signature_algorithm = "RS256"
-					key = "invalid"
-					ttl = 0
-				}
-			}
-			`,
-			"MyToken",
-			`{"sub": "12345"}`,
-			"could not parse rsa private key from pem: MyToken",
 		},
 		{
 			"No profile for label",

--- a/eval/lib/jwt_test.go
+++ b/eval/lib/jwt_test.go
@@ -582,6 +582,36 @@ func TestJwtSignConfigError(t *testing.T) {
 		wantErr  string
 	}{
 		{
+			"multiple jwt_signing_profile blocks with same label",
+			`
+			server "test" {
+			}
+			definitions {
+				jwt_signing_profile "MyToken" {
+					signature_algorithm = "HS256"
+					key = "$3cRe4"
+					ttl = "0"
+					claims = {
+					  iss = to_lower("The_Issuer")
+					  aud = to_upper("The_Audience")
+					}
+				}
+				jwt_signing_profile "MyToken" {
+					signature_algorithm = "HS256"
+					key = "$3cRe4"
+					ttl = "1h"
+					claims = {
+					  iss = to_lower("The_Issuer")
+					  aud = to_upper("The_Audience")
+					}
+				}
+			}
+			`,
+			"MyToken",
+			`{"sub":"12345"}`,
+			"configuration error: jwt_signing_profile block with label MyToken already defined",
+		},
+		{
 			"unsupported signature algorithm",
 			`
 			server "test" {

--- a/eval/lib/jwt_test.go
+++ b/eval/lib/jwt_test.go
@@ -699,6 +699,36 @@ func TestJwtSignConfigError(t *testing.T) {
 			`{"sub": "12345"}`,
 			"configuration error: MySelfSignedToken: invalid Key: Key must be PEM encoded PKCS1 or PKCS8 private key",
 		},
+		{
+			"jwt_signing_profile and jwt with same label",
+			`
+			server "test" {
+			}
+			definitions {
+				jwt "MySelfSignedToken" {
+					signature_algorithm = "HS256"
+					key = "$3cRe4"
+					signing_ttl = "1h"
+					claims = {
+					  iss = to_lower("The_Issuer")
+					  aud = to_upper("The_Audience")
+					}
+				}
+				jwt_signing_profile "MySelfSignedToken" {
+					signature_algorithm = "HS256"
+					key = "$3cRe4"
+					ttl = "0"
+					claims = {
+					  iss = to_lower("The_Issuer")
+					  aud = to_upper("The_Audience")
+					}
+				}
+			}
+			`,
+			"MySelfSignedToken",
+			`{"sub":"12345"}`,
+			"configuration error: jwt_signing_profile or jwt with label MySelfSignedToken already defined",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
In order to simplify local JWT handling (create/sign and check), it should be possible to also reference `jwt` blocks from the `jwt_sign()` function.

To do this, we need
* `signing_ttl` and
* for RSA keys `signing_key`/`signing_key_file`.

So, for JWT signed with an `HS256` key
```
jwt_signing_profile "local_jwt" {
  signature_algorithm = "HS256"
  key = env.LOCAL_JWT_KEY
  ttl = "1h"
}
jwt "local_jwt" {
  signature_algorithm = "HS256"
  key = env.LOCAL_JWT_KEY
  cookie = "local_token"
}
```
could be simplified to

```
jwt "local_jwt" {
  signature_algorithm = "HS256"
  key = env.LOCAL_JWT_KEY
  cookie = "local_token"
  signing_ttl = "1h"
}
```

