### PR TITLE
Conf error in backend used by error handler

### DIFF
--- a/config/runtime/server.go
+++ b/config/runtime/server.go
@@ -567,9 +567,13 @@ func configureProtectedHandler(m ACDefinitions, ctx *hcl.EvalContext, parentAC, 
 		if e := m.MustExist(acName); e != nil {
 			return nil, e
 		}
+		eh, err := newErrorHandler(ctx, opts, log, m, acName)
+		if err != nil {
+			return nil, err
+		}
 		list = append(
 			list,
-			ac.NewItem(acName, m[acName].Control, newErrorHandler(ctx, opts, log, m, acName)),
+			ac.NewItem(acName, m[acName].Control, eh),
 		)
 	}
 
@@ -580,7 +584,7 @@ func configureProtectedHandler(m ACDefinitions, ctx *hcl.EvalContext, parentAC, 
 }
 
 func newErrorHandler(ctx *hcl.EvalContext, opts *protectedOptions, log *logrus.Entry,
-	defs ACDefinitions, references ...string) http.Handler {
+	defs ACDefinitions, references ...string) (http.Handler, error) {
 	kindsHandler := map[string]http.Handler{}
 	for _, ref := range references {
 		for _, h := range defs[ref].ErrorHandler {
@@ -604,7 +608,10 @@ func newErrorHandler(ctx *hcl.EvalContext, opts *protectedOptions, log *logrus.E
 					epConf.Response = &config.Response{Remain: emptyBody}
 				}
 
-				epOpts, _ := newEndpointOptions(ctx, epConf, nil, opts.srvOpts, log, opts.proxyFromEnv, opts.memStore)
+				epOpts, err := newEndpointOptions(ctx, epConf, nil, opts.srvOpts, log, opts.proxyFromEnv, opts.memStore)
+				if err != nil {
+					return nil, err
+				}
 				if epOpts.Error == nil || h.ErrorFile == "" {
 					epOpts.Error = opts.epOpts.Error
 				}
@@ -623,7 +630,7 @@ func newErrorHandler(ctx *hcl.EvalContext, opts *protectedOptions, log *logrus.E
 			}
 		}
 	}
-	return handler.NewErrorHandler(kindsHandler, opts.epOpts.Error)
+	return handler.NewErrorHandler(kindsHandler, opts.epOpts.Error), nil
 }
 
 func setRoutesFromHosts(

--- a/server/http_error_handler_test.go
+++ b/server/http_error_handler_test.go
@@ -116,7 +116,7 @@ func TestAccessControl_ErrorHandler_Configuration_Error(t *testing.T) {
 	log, _ := logrustest.NewNullLogger()
 	ctx := context.TODO()
 
-	expectedMsg := "<nil>: Missing required argument; The argument \"grant_type\" is required, but was not set."
+	expectedMsg := "03_couper.hcl:24,5-11: Missing required argument; The argument \"grant_type\" is required, but was not set."
 
 	err = command.NewRun(ctx).Execute([]string{couperConfig.Filename}, couperConfig, log.WithContext(ctx))
 	if err == nil {

--- a/server/http_error_handler_test.go
+++ b/server/http_error_handler_test.go
@@ -1,9 +1,14 @@
 package server_test
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
+	logrustest "github.com/sirupsen/logrus/hooks/test"
+
+	"github.com/avenga/couper/command"
+	"github.com/avenga/couper/config/configload"
 	"github.com/avenga/couper/internal/test"
 )
 
@@ -100,5 +105,23 @@ func TestAccessControl_ErrorHandler_BasicAuth_Wildcard(t *testing.T) {
 
 	if www := res.Header.Get("www-authenticate"); www != "" {
 		t.Errorf("Expected no www-authenticate header: %s", www)
+	}
+}
+
+func TestAccessControl_ErrorHandler_Configuration_Error(t *testing.T) {
+	helper := test.New(t)
+	couperConfig, err := configload.LoadFile("testdata/integration/error_handler/03_couper.hcl")
+	helper.Must(err)
+
+	log, _ := logrustest.NewNullLogger()
+	ctx := context.TODO()
+
+	expectedMsg := "<nil>: Missing required argument; The argument \"grant_type\" is required, but was not set."
+
+	err = command.NewRun(ctx).Execute([]string{couperConfig.Filename}, couperConfig, log.WithContext(ctx))
+	if err == nil {
+		t.Error("logErr should not be nil")
+	} else if err.Error() != expectedMsg {
+		t.Errorf("\nwant:\t%s\ngot:\t%v", expectedMsg, err.Error())
 	}
 }

--- a/server/testdata/integration/error_handler/03_couper.hcl
+++ b/server/testdata/integration/error_handler/03_couper.hcl
@@ -1,0 +1,31 @@
+server "access_control" {
+  endpoint "/" {
+    access_control = ["ba"]
+    response {
+      status = 204
+    }
+  }
+}
+
+definitions {
+  basic_auth "ba" {
+    password = "couper"
+
+    error_handler {
+      request "another" {
+        url = "https://as/foo"
+        backend = "as"
+      }
+      response {}
+    }
+  }
+  backend "as" {
+    origin = "https://as"
+    oauth2 {
+      # grant_type = "missing attribute!"
+      token_endpoint = "https://as/token"
+      client_id = "my-id"
+      client_secret = "my-secret"
+    }
+  }
+}


### PR DESCRIPTION
Given:
* a missing attribute (like `grant_type`)
* in an `oauth2` block
* in a `backend` block
* referenced from a `request` block
* in an `error_handler` block
* in an access control

```
definitions {

  basic_auth "ba" {
    password = "couper"

    error_handler {
      request "another" {
        url = "https://as/foo"
        backend = "as"
      }
      response {}
    }
  }
  backend "as" {
    origin = "https://as"
    oauth2 {
      # grant_type = "missing attribute!"
      token_endpoint = "https://as/token"
      client_id = "my-id"
      client_secret = "my-secret"
    }
  }
}
```
This should not result in a panic.