### PR TITLE
Improve interface to obtain eval.Context

### DIFF
--- a/accesscontrol/ac.go
+++ b/accesscontrol/ac.go
@@ -3,7 +3,6 @@ package accesscontrol
 import (
 	"net/http"
 
-	"github.com/avenga/couper/config/request"
 	"github.com/avenga/couper/errors"
 	"github.com/avenga/couper/eval"
 )
@@ -48,9 +47,8 @@ func (i ListItem) Validate(req *http.Request) error {
 		return errors.AccessControl.Label(i.label).Kind(i.kind).With(err)
 	}
 
-	if evalCtx, ok := req.Context().Value(request.ContextType).(*eval.Context); ok {
-		*req = *req.WithContext(evalCtx.WithClientRequest(req))
-	}
+	evalCtx := eval.ContextFromRequest(req)
+	*req = *req.WithContext(evalCtx.WithClientRequest(req))
 
 	return nil
 }

--- a/eval/context.go
+++ b/eval/context.go
@@ -73,6 +73,15 @@ func NewContext(src []byte, defaults *config.Defaults) *Context {
 	}
 }
 
+// ContextFromRequest extracts the eval.Context implementation value from given request and
+// returns a noop one as fallback.
+func ContextFromRequest(req *http.Request) *Context {
+	if evalCtx, ok := req.Context().Value(request.ContextType).(*Context); ok {
+		return evalCtx
+	}
+	return NewContext(nil, nil)
+}
+
 func (c *Context) Deadline() (deadline time.Time, ok bool) {
 	return c.inner.Deadline()
 }

--- a/handler/endpoint.go
+++ b/handler/endpoint.go
@@ -110,7 +110,7 @@ func (e *Endpoint) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	default:
 	}
 
-	evalContext := req.Context().Value(request.ContextType).(*eval.Context)
+	evalContext := eval.ContextFromRequest(req)
 	evalContext = evalContext.WithBeresps(beresps.List()...)
 
 	// assume prio or err on conf load if set with response

--- a/handler/file.go
+++ b/handler/file.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 
-	"github.com/avenga/couper/config/request"
 	"github.com/avenga/couper/config/runtime/server"
 	"github.com/avenga/couper/errors"
 	"github.com/avenga/couper/eval"
@@ -90,7 +89,7 @@ func (f *File) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	if r, ok := rw.(*writer.Response); ok {
-		evalContext := req.Context().Value(request.ContextType).(*eval.Context)
+		evalContext := eval.ContextFromRequest(req)
 		r.AddModifier(evalContext, f.modifier)
 	}
 
@@ -105,7 +104,7 @@ func (f *File) serveDirectory(reqPath string, rw http.ResponseWriter, req *http.
 
 	if !strings.HasSuffix(reqPath, "/") {
 		if r, ok := rw.(*writer.Response); ok {
-			evalContext := req.Context().Value(request.ContextType).(*eval.Context)
+			evalContext := eval.ContextFromRequest(req)
 			r.AddModifier(evalContext, f.modifier)
 		}
 
@@ -124,7 +123,7 @@ func (f *File) serveDirectory(reqPath string, rw http.ResponseWriter, req *http.
 	defer file.Close()
 
 	if r, ok := rw.(*writer.Response); ok {
-		evalContext := req.Context().Value(request.ContextType).(*eval.Context)
+		evalContext := eval.ContextFromRequest(req)
 		r.AddModifier(evalContext, f.modifier)
 	}
 

--- a/handler/proxy.go
+++ b/handler/proxy.go
@@ -176,7 +176,7 @@ func (p *Proxy) registerWebsocketsResponse(req *http.Request, rw *writer.Respons
 		return err
 	}
 
-	evalCtx := req.Context().Value(request.ContextType).(*eval.Context)
+	evalCtx := eval.ContextFromRequest(req)
 	if rw != nil {
 		rw.AddModifier(evalCtx, []hcl.Body{wsBody, p.context})
 	}

--- a/handler/spa.go
+++ b/handler/spa.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 
-	"github.com/avenga/couper/config/request"
 	"github.com/avenga/couper/config/runtime/server"
 	"github.com/avenga/couper/errors"
 	"github.com/avenga/couper/eval"
@@ -62,7 +61,7 @@ func (s *Spa) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	if r, ok := rw.(*writer.Response); ok {
-		evalContext := req.Context().Value(request.ContextType).(*eval.Context)
+		evalContext := eval.ContextFromRequest(req)
 		r.AddModifier(evalContext, s.modifier)
 	}
 

--- a/handler/transport/backend.go
+++ b/handler/transport/backend.go
@@ -136,13 +136,10 @@ func (b *Backend) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	// Backend response context creates the beresp variables in first place and applies this context
 	// to the current beresp obj. Downstream response context evals reading their beresp variable values
-	// from this result. Fallback case is for testing purposes.
-	if evalCtx, ok := req.Context().Value(request.ContextType).(*eval.Context); ok {
-		evalCtx = evalCtx.WithBeresps(beresp)
-		err = eval.ApplyResponseContext(evalCtx, b.context, beresp)
-	} else {
-		err = eval.ApplyResponseContext(req.Context(), b.context, beresp)
-	}
+	// from this result.
+	evalCtx := eval.ContextFromRequest(req)
+	evalCtx = evalCtx.WithBeresps(beresp)
+	err = eval.ApplyResponseContext(evalCtx, b.context, beresp)
 
 	return beresp, err
 }


### PR DESCRIPTION
Small change to obtain ctx with less checks

---
<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>
