### PR TITLE
Fixed key for reading openid configuration from storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Unreleased changes are available as `avenga/couper:edge` container.
 * **Changed**
   * Organized log format fields for uniform access and upstream log ([#300](https://github.com/avenga/couper/pull/300))
 
+* **Fixed**
+  * Key for storing and reading [OpenID configuration](./docs/REFERENCE.md#oidc-block-beta) ([#319](https://github.com/avenga/couper/pull/319))
+
 ---
 
 ## [1.4](https://github.com/avenga/couper/releases/tag/1.4)

--- a/oauth2/oidc/config.go
+++ b/oauth2/oidc/config.go
@@ -186,7 +186,8 @@ func (o *Config) fetchConfiguration(uid string) (*OpenidConfiguration, error) {
 		return nil, err
 	}
 
-	o.memStore.Set(o.ConfigurationURL, openidConfiguration, o.ttl)
+	key := o.Name + o.ConfigurationURL
+	o.memStore.Set(key, openidConfiguration, o.ttl)
 	return openidConfiguration, nil
 }
 


### PR DESCRIPTION
Fix: key for storing and reading openid configuration

---
<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>
