### PR TITLE
OAuth2 CC backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Unreleased changes are available as `avenga/couper:edge` container.
 * **Fixed**
   * Handling of [`accept_forwarded_url`](./docs/REFERENCE.md#settings-block) "host" if `H-Forwarded-Host` request header field contains a port ([#360](https://github.com/avenga/couper/pull/360))
   * Setting `Vary` response header fields for [CORS](./doc/REFERENCE.md#cors-block) ([#362](https://github.com/avenga/couper/pull/362))
+  * Using of backends via references in [OAuth2 CC Blocks](./docs/REFERENCE.md#oauth2-cc-block) ([#321](https://github.com/avenga/couper/issues/321))
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Unreleased changes are available as `avenga/couper:edge` container.
 * **Fixed**
   * Handling of [`accept_forwarded_url`](./docs/REFERENCE.md#settings-block) "host" if `H-Forwarded-Host` request header field contains a port ([#360](https://github.com/avenga/couper/pull/360))
   * Setting `Vary` response header fields for [CORS](./doc/REFERENCE.md#cors-block) ([#362](https://github.com/avenga/couper/pull/362))
-  * Using of backends via references in [OAuth2 CC Blocks](./docs/REFERENCE.md#oauth2-cc-block) ([#321](https://github.com/avenga/couper/issues/321))
+  * Use of referenced backends in [OAuth2 CC Blocks](./docs/REFERENCE.md#oauth2-cc-block) ([#321](https://github.com/avenga/couper/issues/321))
 
 ---
 

--- a/config/configload/load.go
+++ b/config/configload/load.go
@@ -160,7 +160,7 @@ func LoadConfig(body hcl.Body, src []byte, filename string) (*config.Couper, err
 				}
 				oauth2Config.BodyContent = bodyContent
 
-				oauth2Config.Backend, err = newBackend(definedBackends, oauth2Config)
+				oauth2Config.Backend, err = newBackend(envContext, definedBackends, oauth2Config)
 				if err != nil {
 					return nil, err
 				}
@@ -178,7 +178,7 @@ func LoadConfig(body hcl.Body, src []byte, filename string) (*config.Couper, err
 				}
 				oidcConfig.BodyContent = bodyContent
 
-				oidcConfig.Backend, err = newBackend(definedBackends, oidcConfig)
+				oidcConfig.Backend, err = newBackend(envContext, definedBackends, oidcConfig)
 				if err != nil {
 					return nil, err
 				}
@@ -197,7 +197,7 @@ func LoadConfig(body hcl.Body, src []byte, filename string) (*config.Couper, err
 					}
 					jwtConfig.BodyContent = bodyContent
 
-					jwtConfig.Backend, err = newBackend(definedBackends, jwtConfig)
+					jwtConfig.Backend, err = newBackend(envContext, definedBackends, jwtConfig)
 					if err != nil {
 						return nil, err
 					}
@@ -235,7 +235,7 @@ func LoadConfig(body hcl.Body, src []byte, filename string) (*config.Couper, err
 				acContent := bodyToContent(acBody.HCLBody())
 				configuredLabels := map[string]struct{}{}
 				for _, block := range acContent.Blocks.OfType(errorHandler) {
-					errHandlerConf, err := newErrorHandlerConf(block.Labels, block.Body, definedBackends)
+					errHandlerConf, err := newErrorHandlerConf(envContext, block.Labels, block.Body, definedBackends)
 					if err != nil {
 						return nil, err
 					}
@@ -397,7 +397,7 @@ func LoadConfig(body hcl.Body, src []byte, filename string) (*config.Couper, err
 		}
 
 		// standalone endpoints
-		err := refineEndpoints(definedBackends, serverConfig.Endpoints, true)
+		err := refineEndpoints(envContext, definedBackends, serverConfig.Endpoints, true)
 		if err != nil {
 			return nil, err
 		}
@@ -503,7 +503,7 @@ func getBackendReference(definedBackends Backends, be config.BackendReference) (
 	return reference, nil
 }
 
-func refineEndpoints(definedBackends Backends, endpoints config.Endpoints, check bool) error {
+func refineEndpoints(ctx *hcl.EvalContext, definedBackends Backends, endpoints config.Endpoints, check bool) error {
 	for _, endpoint := range endpoints {
 		if err := uniqueAttributeKey(endpoint.Remain); err != nil {
 			return err
@@ -574,7 +574,7 @@ func refineEndpoints(definedBackends Backends, endpoints config.Endpoints, check
 				return err
 			}
 
-			proxyConfig.Backend, err = newBackend(definedBackends, proxyConfig)
+			proxyConfig.Backend, err = newBackend(ctx, definedBackends, proxyConfig)
 			if err != nil {
 				return err
 			}
@@ -615,7 +615,7 @@ func refineEndpoints(definedBackends Backends, endpoints config.Endpoints, check
 				return err
 			}
 
-			reqConfig.Backend, err = newBackend(definedBackends, reqConfig)
+			reqConfig.Backend, err = newBackend(ctx, definedBackends, reqConfig)
 			if err != nil {
 				return err
 			}
@@ -783,7 +783,7 @@ func contentByType(blockType string, body hcl.Body) (*hcl.BodyContent, error) {
 	return content, nil
 }
 
-func newBackend(definedBackends Backends, inlineConfig config.Inline) (hcl.Body, error) {
+func newBackend(ctx *hcl.EvalContext, definedBackends Backends, inlineConfig config.Inline) (hcl.Body, error) {
 	bend, err := mergeBackendBodies(definedBackends, inlineConfig)
 	if err != nil {
 		return nil, err
@@ -803,7 +803,7 @@ func newBackend(definedBackends Backends, inlineConfig config.Inline) (hcl.Body,
 		})
 	}
 
-	oauth2Backend, err := newOAuthBackend(definedBackends, bend)
+	oauth2Backend, err := newOAuthBackend(ctx, definedBackends, bend)
 	if err != nil {
 		return nil, err
 	}
@@ -842,7 +842,7 @@ func createCatchAllEndpoint() *config.Endpoint {
 	}
 }
 
-func newOAuthBackend(definedBackends Backends, parent hcl.Body) (hcl.Body, error) {
+func newOAuthBackend(ctx *hcl.EvalContext, definedBackends Backends, parent hcl.Body) (hcl.Body, error) {
 	innerContent, err := contentByType(oauth2, parent)
 	if err != nil {
 		return nil, err
@@ -858,19 +858,33 @@ func newOAuthBackend(definedBackends Backends, parent hcl.Body) (hcl.Body, error
 		return nil, err
 	}
 
-	oauthBackend, err := mergeBackendBodies(definedBackends, &config.Backend{Remain: hclbody.New(backendContent)})
+	beConfig := &config.Backend{Remain: hclbody.New(backendContent)}
+
+	// The <ctx> can be nil in test cases.
+	if ctx != nil {
+		attrs, _ := oauthBlocks[0].Body.JustAttributes()
+		if attrs != nil && attrs["backend"] != nil {
+			val, _ := attrs["backend"].Expr.Value(ctx)
+
+			if ref := seetie.ValueToString(val); ref != "" {
+				beConfig.Name = ref
+			}
+		}
+	}
+
+	oauthBackend, err := mergeBackendBodies(definedBackends, beConfig)
 	if err != nil {
 		return nil, err
 	}
 
-	return newBackend(definedBackends, &config.OAuth2ReqAuth{Remain: hclbody.New(&hcl.BodyContent{
+	return newBackend(ctx, definedBackends, &config.OAuth2ReqAuth{Remain: hclbody.New(&hcl.BodyContent{
 		Blocks: []*hcl.Block{
 			{Type: backend, Body: oauthBackend},
 		},
 	})})
 }
 
-func newErrorHandlerConf(kindLabels []string, body hcl.Body, definedBackends Backends) (*config.ErrorHandler, error) {
+func newErrorHandlerConf(ctx *hcl.EvalContext, kindLabels []string, body hcl.Body, definedBackends Backends) (*config.ErrorHandler, error) {
 	var allKinds []string // Support for all events within one label separated by space
 
 	for _, kinds := range kindLabels {
@@ -897,7 +911,7 @@ func newErrorHandlerConf(kindLabels []string, body hcl.Body, definedBackends Bac
 		Remain:    body,
 	}
 
-	if err := refineEndpoints(definedBackends, config.Endpoints{ep}, false); err != nil {
+	if err := refineEndpoints(ctx, definedBackends, config.Endpoints{ep}, false); err != nil {
 		return nil, err
 	}
 

--- a/config/configload/load.go
+++ b/config/configload/load.go
@@ -335,7 +335,7 @@ func LoadConfig(body hcl.Body, src []byte, filename string) (*config.Couper, err
 		saml.MetadataBytes = metadata
 	}
 
-	jwtSigningConfigs := make(map[string]*lib.JWTSigningConfig, 0)
+	jwtSigningConfigs := make(map[string]*lib.JWTSigningConfig)
 	for _, profile := range couperConfig.Definitions.JWTSigningProfile {
 		if _, exists := jwtSigningConfigs[profile.Name]; exists {
 			return nil, errors.Configuration.Messagef("jwt_signing_profile block with label %s already defined", profile.Name)

--- a/config/configload/load_test.go
+++ b/config/configload/load_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func Test_refineEndpoints_noPattern(t *testing.T) {
-	err := refineEndpoints(nil, config.Endpoints{{Pattern: ""}}, true)
+	err := refineEndpoints(nil, nil, config.Endpoints{{Pattern: ""}}, true)
 	if err == nil || !strings.HasSuffix(err.Error(), "endpoint: missing path pattern; ") {
 		t.Errorf("refineEndpoints() error = %v, wantErr: endpoint: missing path pattern ", err)
 	}

--- a/config/configload/load_test.go
+++ b/config/configload/load_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func Test_refineEndpoints_noPattern(t *testing.T) {
-	err := refineEndpoints(nil, nil, config.Endpoints{{Pattern: ""}}, true)
+	err := refineEndpoints(nil, config.Endpoints{{Pattern: ""}}, true)
 	if err == nil || !strings.HasSuffix(err.Error(), "endpoint: missing path pattern; ") {
 		t.Errorf("refineEndpoints() error = %v, wantErr: endpoint: missing path pattern ", err)
 	}

--- a/server/http_oauth2_test.go
+++ b/server/http_oauth2_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/dgrijalva/jwt-go/v4"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
 
 	"github.com/avenga/couper/eval/lib"
 	"github.com/avenga/couper/internal/test"
@@ -385,6 +386,206 @@ func TestOAuth2_AccessControl(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestOAuth2_AC_Backend(t *testing.T) {
+	client := newClient()
+	helper := test.New(t)
+
+	// authorization server creates token response with sub property, JWT ID token with sub claim and userinfo response with sub property from X-Sub request header
+	asOrigin := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		sub := req.Header.Get("X-Sub")
+		if req.URL.Path == "/token" {
+			rw.Header().Set("Content-Type", "application/json")
+			rw.WriteHeader(http.StatusOK)
+			mapClaims := jwt.MapClaims{
+				"iss": "https://authorization.server",
+				"aud": "foo",
+				"sub": "myself",
+				"exp": 4000000000,
+				"iat": 1000,
+			}
+			idToken, _ := lib.CreateJWT("HS256", []byte("$e(rEt"), mapClaims)
+			idTokenToAdd := `"id_token":"` + idToken + `",
+			`
+
+			body := []byte(`{
+				"access_token": "abcdef0123456789",
+				` + idTokenToAdd +
+				`"sub": "` + sub + `"
+			}`)
+			_, werr := rw.Write(body)
+			helper.Must(werr)
+
+			return
+		} else if req.URL.Path == "/userinfo" {
+			body := []byte(`{"sub": "` + sub + `"}`)
+			_, werr := rw.Write(body)
+			helper.Must(werr)
+
+			return
+		} else if req.URL.Path == "/.well-known/openid-configuration" {
+			body := []byte(`{
+			"issuer": "https://authorization.server",
+			"authorization_endpoint": "https://authorization.server/oauth2/authorize",
+			"token_endpoint": "http://` + req.Host + `/token",
+			"userinfo_endpoint": "http://` + req.Host + `/userinfo"
+			}`)
+			_, werr := rw.Write(body)
+			helper.Must(werr)
+
+			return
+		}
+		rw.WriteHeader(http.StatusBadRequest)
+	}))
+	defer asOrigin.Close()
+
+	type testCase struct {
+		name        string
+		path        string
+		backendName string
+	}
+
+	for _, tc := range []testCase{
+		{"OAuth2 Authorization Code, referenced backend", "/oauth1/redir?code=qeuboub", "as"},
+		{"OAuth2 Authorization Code, inline backend", "/oauth2/redir?code=qeuboub", "default"},
+		{"OIDC Authorization Code, referenced backend", "/oidc1/redir?code=qeuboub", "as"},
+		{"OIDC Authorization Code, inline backend", "/oidc2/redir?code=qeuboub", "default"},
+	} {
+		t.Run(tc.name, func(subT *testing.T) {
+			shutdown, hook := newCouperWithTemplate("testdata/oauth2/11_couper.hcl", test.New(t), map[string]interface{}{"asOrigin": asOrigin.URL})
+			defer shutdown()
+
+			helper := test.New(subT)
+
+			req, err := http.NewRequest(http.MethodGet, "http://back.end:8080"+tc.path, nil)
+			helper.Must(err)
+
+			req.Header.Set("Cookie", "pkcecv=qerbnr")
+
+			res, err := client.Do(req)
+			helper.Must(err)
+
+			if res.StatusCode != http.StatusOK {
+				subT.Errorf("expected Status %d, got: %d", http.StatusOK, res.StatusCode)
+			}
+
+			tokenResBytes, err := io.ReadAll(res.Body)
+			helper.Must(err)
+
+			var jData map[string]interface{}
+			json.Unmarshal(tokenResBytes, &jData)
+			if sub, ok := jData["sub"]; ok {
+				if sub != "myself" {
+					subT.Errorf("expected sub %q, got: %q", "myself", sub)
+				}
+			} else {
+				subT.Errorf("expected sub %q, got no", "myself")
+			}
+
+			backendName := getUpstreamLogBackendName(hook)
+			if backendName != tc.backendName {
+				subT.Errorf("expected backend name %q, got: %q", tc.backendName, backendName)
+			}
+		})
+	}
+}
+
+func getBearer(val string) (string, error) {
+	const bearer = "bearer "
+	if strings.HasPrefix(strings.ToLower(val), bearer) {
+		return strings.Trim(val[len(bearer):], " "), nil
+	}
+	return "", fmt.Errorf("bearer required with authorization header")
+}
+
+func TestOAuth2_CC_Backend(t *testing.T) {
+	client := newClient()
+	helper := test.New(t)
+
+	// authorization server creates JWT access token with sub claim from X-Sub request header
+	asOrigin := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		sub := req.Header.Get("X-Sub")
+		if req.URL.Path == "/token" {
+			rw.Header().Set("Content-Type", "application/json")
+			rw.WriteHeader(http.StatusOK)
+			mapClaims := jwt.MapClaims{"sub": sub}
+			accessToken, _ := lib.CreateJWT("HS256", []byte("$e(rEt"), mapClaims)
+			body := []byte(`{"access_token": "` + accessToken + `"}`)
+			_, werr := rw.Write(body)
+			helper.Must(werr)
+
+			return
+		}
+		rw.WriteHeader(http.StatusBadRequest)
+	}))
+	defer asOrigin.Close()
+
+	// resource server sends value of sub claim of JWT bearer token
+	rsOrigin := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		authorization := req.Header.Get("Authorization")
+		tokenString, err := getBearer(authorization)
+		helper.Must(err)
+		jwtParser := jwt.NewParser()
+		claims := jwt.MapClaims{}
+		_, _, err = jwtParser.ParseUnverified(tokenString, claims)
+		helper.Must(err)
+		sub := claims["sub"].(string)
+
+		rw.Header().Set("X-Sub2", sub)
+		rw.WriteHeader(http.StatusNoContent)
+	}))
+	defer rsOrigin.Close()
+
+	type testCase struct {
+		name        string
+		path        string
+		backendName string
+	}
+
+	for _, tc := range []testCase{
+		{"referenced backend", "/rs1", "as"},
+		{"inline backend", "/rs2", "default"},
+	} {
+		t.Run(tc.name, func(subT *testing.T) {
+			shutdown, hook := newCouperWithTemplate("testdata/oauth2/11_couper.hcl", test.New(t), map[string]interface{}{"asOrigin": asOrigin.URL, "rsOrigin": rsOrigin.URL})
+			defer shutdown()
+
+			helper := test.New(subT)
+
+			req, err := http.NewRequest(http.MethodGet, "http://back.end:8080"+tc.path, nil)
+			helper.Must(err)
+
+			res, err := client.Do(req)
+			helper.Must(err)
+
+			if res.StatusCode != http.StatusNoContent {
+				subT.Errorf("expected Status %d, got: %d", http.StatusNoContent, res.StatusCode)
+			}
+
+			sub := res.Header.Get("X-Sub2")
+			if sub != "myself" {
+				subT.Errorf("expected sub %q, got: %q", "myself", sub)
+			}
+
+			backendName := getUpstreamLogBackendName(hook)
+			if backendName != tc.backendName {
+				subT.Errorf("expected backend name %q, got: %q", tc.backendName, backendName)
+			}
+		})
+	}
+}
+
+func getUpstreamLogBackendName(hook *logrustest.Hook) string {
+	for _, entry := range hook.AllEntries() {
+		if entry.Data["type"] == "couper_backend" && entry.Data["backend"] != "" {
+			if backend, ok := entry.Data["backend"].(string); ok {
+				return backend
+			}
+		}
+	}
+
+	return ""
 }
 
 func TestOAuth2_Locking(t *testing.T) {

--- a/server/http_oauth2_test.go
+++ b/server/http_oauth2_test.go
@@ -405,7 +405,7 @@ func TestOAuth2_AC_Backend(t *testing.T) {
 				"exp": 4000000000,
 				"iat": 1000,
 			}
-			idToken, _ := lib.CreateJWT("HS256", []byte("$e(rEt"), mapClaims)
+			idToken, _ := lib.CreateJWT("HS256", []byte("$e(rEt"), mapClaims, nil)
 			idTokenToAdd := `"id_token":"` + idToken + `",
 			`
 
@@ -510,7 +510,7 @@ func TestOAuth2_CC_Backend(t *testing.T) {
 			rw.Header().Set("Content-Type", "application/json")
 			rw.WriteHeader(http.StatusOK)
 			mapClaims := jwt.MapClaims{"sub": sub}
-			accessToken, _ := lib.CreateJWT("HS256", []byte("$e(rEt"), mapClaims)
+			accessToken, _ := lib.CreateJWT("HS256", []byte("$e(rEt"), mapClaims, nil)
 			body := []byte(`{"access_token": "` + accessToken + `"}`)
 			_, werr := rw.Write(body)
 			helper.Must(werr)

--- a/server/testdata/oauth2/11_couper.hcl
+++ b/server/testdata/oauth2/11_couper.hcl
@@ -1,0 +1,135 @@
+server "oauth-client" {
+  api {
+    endpoint "/rs1" {
+      proxy {
+        backend = "rs1"
+      }
+    }
+    endpoint "/rs2" {
+      proxy {
+        backend = "rs2"
+      }
+    }
+  }
+  endpoint "/oauth1/redir" {
+    access_control = ["ac-oauth-1"]
+    response {
+      json_body = request.context.ac-oauth-1
+    }
+  }
+  endpoint "/oauth2/redir" {
+    access_control = ["ac-oauth-2"]
+    response {
+      json_body = request.context.ac-oauth-2
+    }
+  }
+  endpoint "/oidc1/redir" {
+    access_control = ["ac-oidc-1"]
+    response {
+      json_body = request.context.ac-oidc-1
+    }
+  }
+  endpoint "/oidc2/redir" {
+    access_control = ["ac-oidc-2"]
+    response {
+      json_body = request.context.ac-oidc-2
+    }
+  }
+}
+definitions {
+  # with referenced backend
+  beta_oauth2 "ac-oauth-1" {
+    authorization_endpoint = "{{.asOrigin}}/auth"
+    token_endpoint = "{{.asOrigin}}/token"
+    backend = "as"
+    client_id = "foo"
+    client_secret = "etbinbp4in"
+    grant_type = "authorization_code"
+    verifier_method = "ccm_s256"
+    verifier_value = request.cookies.pkcecv
+    redirect_uri = "http://localhost:8080/oauth/redir"
+  }
+  # with inline backend
+  beta_oauth2 "ac-oauth-2" {
+    authorization_endpoint = "{{.asOrigin}}/auth"
+    token_endpoint = "{{.asOrigin}}/token"
+    backend {
+      origin = "{{.asOrigin}}"
+      add_request_headers = {
+        x-sub = "myself"
+      }
+    }
+    client_id = "foo"
+    client_secret = "etbinbp4in"
+    grant_type = "authorization_code"
+    verifier_method = "ccm_s256"
+    verifier_value = request.cookies.pkcecv
+    redirect_uri = "http://localhost:8080/oauth/redir"
+  }
+
+  # with referenced backend
+  beta_oidc "ac-oidc-1" {
+    configuration_url = "{{.asOrigin}}/.well-known/openid-configuration"
+    configuration_ttl = "1h"
+    backend = "as"
+    client_id = "foo"
+    client_secret = "etbinbp4in"
+    verifier_method = "ccm_s256"
+    verifier_value = request.cookies.pkcecv
+    redirect_uri = "http://localhost:8080/oidc/redir"
+  }
+  # with inline backend
+  beta_oidc "ac-oidc-2" {
+    configuration_url = "{{.asOrigin}}/.well-known/openid-configuration"
+    configuration_ttl = "1h"
+    backend {
+      origin = "{{.asOrigin}}"
+      add_request_headers = {
+        x-sub = "myself"
+      }
+    }
+    client_id = "foo"
+    client_secret = "etbinbp4in"
+    verifier_method = "ccm_s256"
+    verifier_value = request.cookies.pkcecv
+    redirect_uri = "http://localhost:8080/oidc/redir"
+  }
+
+  # backends for resource server
+  # with referenced backend
+  backend "rs1" {
+    origin = "{{.rsOrigin}}"
+    oauth2 {
+      token_endpoint = "{{.asOrigin}}/token"
+      backend = "as"
+      client_id = "foo"
+      client_secret = "etbinbp4in"
+      grant_type = "client_credentials"
+    }
+  }
+  # with inline backend
+  backend "rs2" {
+    origin = "{{.rsOrigin}}"
+    oauth2 {
+      token_endpoint = "{{.asOrigin}}/token"
+      backend {
+        origin = "{{.asOrigin}}"
+        add_request_headers = {
+          x-sub = "myself"
+        }
+      }
+      client_id = "foo"
+      client_secret = "etbinbp4in"
+      grant_type = "client_credentials"
+    }
+  }
+
+  # backend for authorization server
+  backend "as" {
+    origin = "{{.asOrigin}}"
+    add_request_headers = {
+      x-sub = "myself"
+    }
+  }
+
+}


### PR DESCRIPTION
The config for the backend in a OAuth2 block now contains the reference-backend-name, too.

---
<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>
