### PR TITLE
Fix possible data race while creating trace context

### DIFF
--- a/logging/upstream_log.go
+++ b/logging/upstream_log.go
@@ -39,7 +39,7 @@ func NewUpstreamLog(log *logrus.Entry, next http.RoundTripper, ignoreProxyEnv bo
 func (u *UpstreamLog) RoundTrip(req *http.Request) (*http.Response, error) {
 	startTime := time.Now()
 
-	timings, timingsMu := u.withTraceContext(req)
+	timings, timingsMu, clientTrace := u.newTraceContext()
 
 	fields := Fields{
 		"uid":    req.Context().Value(request.UID),
@@ -73,7 +73,8 @@ func (u *UpstreamLog) RoundTrip(req *http.Request) (*http.Response, error) {
 	*req = *req.WithContext(oCtx)
 
 	rtStart := time.Now()
-	beresp, err := u.next.RoundTrip(req)
+	beresp, err := u.next.RoundTrip(
+		req.WithContext(httptrace.WithClientTrace(req.Context(), clientTrace)))
 	rtDone := time.Now()
 
 	if req.Host != "" {
@@ -156,7 +157,7 @@ func (u *UpstreamLog) LogEntry() *logrus.Entry {
 	return u.log
 }
 
-func (u *UpstreamLog) withTraceContext(req *http.Request) (Fields, *sync.RWMutex) {
+func (u *UpstreamLog) newTraceContext() (Fields, *sync.RWMutex, *httptrace.ClientTrace) {
 	timings := Fields{}
 	mapMu := &sync.RWMutex{}
 	var timeTTFB, timeGotConn, timeConnect, timeDNS, timeTLS time.Time
@@ -211,7 +212,6 @@ func (u *UpstreamLog) withTraceContext(req *http.Request) (Fields, *sync.RWMutex
 			}
 		},
 	}
-	ctx := httptrace.WithClientTrace(req.Context(), trace)
-	*req = *req.WithContext(ctx)
-	return timings, mapMu
+
+	return timings, mapMu, trace
 }


### PR DESCRIPTION
e.g. client cancel

replacing the (client) request ptr value seems to be obsolete.

---
<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>
