### PR TITLE
Role scope map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ Unreleased changes are available as `avenga/couper:edge` container.
   * `Accept: application/json` request header to the OAuth2 token request, in order to make the Github token endpoint respond with a JSON token response ([#307](https://github.com/avenga/couper/pull/307))
   * Documentation of [logs](docs/LOGS.md) ([#310](https://github.com/avenga/couper/pull/310))
   * `signing_ttl` and `signing_key`/`signing_key_file` to [`jwt` block](./docs/REFERENCE.md#jwt-block) for use with [`jwt_sign()` function](#functions) ([#309](https://github.com/avenga/couper/pull/309))
-  * `beta_scope_claim` attribute to [`jwt` block](./docs/REFERENCE.md#jwt-block); `beta_scope` attribute to [`api`](./docs/REFERENCE.md#api-block) and [`endpoint` block](./docs/REFERENCE.md#endpoint-block)s; [error types](./docs/ERRORS.md#error-types) `beta_operation_denied` and `beta_insufficient_scope` ([#315](https://github.com/avenga/couper/pull/315))
   * `jwks_url` and `jwks_ttl` to [`jwt` block](./docs/REFERENCE.md#jwt-block) ([#312](https://github.com/avenga/couper/pull/312))
 
 * **Changed**
@@ -17,6 +16,10 @@ Unreleased changes are available as `avenga/couper:edge` container.
 
 * **Fixed**
   * Key for storing and reading [OpenID configuration](./docs/REFERENCE.md#oidc-block-beta) ([#319](https://github.com/avenga/couper/pull/319))
+
+* [**Beta**](./docs/BETA.md)
+  * `beta_scope_claim` attribute to [`jwt` block](./docs/REFERENCE.md#jwt-block); `beta_scope` attribute to [`api`](./docs/REFERENCE.md#api-block) and [`endpoint` block](./docs/REFERENCE.md#endpoint-block)s; [error types](./docs/ERRORS.md#error-types) `beta_operation_denied` and `beta_insufficient_scope` ([#315](https://github.com/avenga/couper/pull/315))
+  * `beta_role_claim` and `beta_role_map` attributes to [`jwt` block](./docs/REFERENCE.md#jwt-block) ([#325](https://github.com/avenga/couper/pull/325))
 
 ---
 

--- a/config/ac_jwt.go
+++ b/config/ac_jwt.go
@@ -16,25 +16,25 @@ type Claims hcl.Expression
 // JWT represents the <JWT> object.
 type JWT struct {
 	AccessControlSetter
-	Claims             Claims   `hcl:"claims,optional"`
-	ClaimsRequired     []string `hcl:"required_claims,optional"`
-	Cookie             string   `hcl:"cookie,optional"`
-	Header             string   `hcl:"header,optional"`
-	JWKsURL            string   `hcl:"jwks_url,optional"`
-	JWKsTTL            string   `hcl:"jwks_ttl,optional"`
-	JWKSBackendRef     string   `hcl:"backend,optional"`
-	Key                string   `hcl:"key,optional"`
-	KeyFile            string   `hcl:"key_file,optional"`
-	Name               string   `hcl:"name,label"`
-	PostParam          string   `hcl:"post_param,optional"`
-	QueryParam         string   `hcl:"query_param,optional"`
-	RoleClaim          string   `hcl:"beta_role_claim,optional"`
+	Claims             Claims              `hcl:"claims,optional"`
+	ClaimsRequired     []string            `hcl:"required_claims,optional"`
+	Cookie             string              `hcl:"cookie,optional"`
+	Header             string              `hcl:"header,optional"`
+	JWKsURL            string              `hcl:"jwks_url,optional"`
+	JWKsTTL            string              `hcl:"jwks_ttl,optional"`
+	JWKSBackendRef     string              `hcl:"backend,optional"`
+	Key                string              `hcl:"key,optional"`
+	KeyFile            string              `hcl:"key_file,optional"`
+	Name               string              `hcl:"name,label"`
+	PostParam          string              `hcl:"post_param,optional"`
+	QueryParam         string              `hcl:"query_param,optional"`
+	RoleClaim          string              `hcl:"beta_role_claim,optional"`
 	RoleMap            map[string][]string `hcl:"beta_role_map,optional"`
-	ScopeClaim         string   `hcl:"beta_scope_claim,optional"`
-	SignatureAlgorithm string   `hcl:"signature_algorithm,optional"`
-	SigningKey         string   `hcl:"signing_key,optional"`
-	SigningKeyFile     string   `hcl:"signing_key_file,optional"`
-	SigningTTL         string   `hcl:"signing_ttl,optional"`
+	ScopeClaim         string              `hcl:"beta_scope_claim,optional"`
+	SignatureAlgorithm string              `hcl:"signature_algorithm,optional"`
+	SigningKey         string              `hcl:"signing_key,optional"`
+	SigningKeyFile     string              `hcl:"signing_key_file,optional"`
+	SigningTTL         string              `hcl:"signing_ttl,optional"`
 
 	// Internally used
 	BodyContent     *hcl.BodyContent

--- a/config/ac_jwt.go
+++ b/config/ac_jwt.go
@@ -28,6 +28,8 @@ type JWT struct {
 	Name               string   `hcl:"name,label"`
 	PostParam          string   `hcl:"post_param,optional"`
 	QueryParam         string   `hcl:"query_param,optional"`
+	RoleClaim          string   `hcl:"beta_role_claim,optional"`
+	RoleMap            map[string][]string `hcl:"beta_role_map,optional"`
 	ScopeClaim         string   `hcl:"beta_scope_claim,optional"`
 	SignatureAlgorithm string   `hcl:"signature_algorithm,optional"`
 	SigningKey         string   `hcl:"signing_key,optional"`

--- a/config/runtime/server.go
+++ b/config/runtime/server.go
@@ -480,6 +480,8 @@ func configureAccessControls(conf *config.Couper, confCtx *hcl.EvalContext, log 
 					Claims:         jwtConf.Claims,
 					ClaimsRequired: jwtConf.ClaimsRequired,
 					Name:           jwtConf.Name,
+					RoleClaim:      jwtConf.RoleClaim,
+					RoleMap:        jwtConf.RoleMap,
 					ScopeClaim:     jwtConf.ScopeClaim,
 					Source:         ac.NewJWTSource(jwtConf.Cookie, jwtConf.Header),
 					JWKS:           jwks,
@@ -499,6 +501,8 @@ func configureAccessControls(conf *config.Couper, confCtx *hcl.EvalContext, log 
 					ClaimsRequired: jwtConf.ClaimsRequired,
 					Key:            key,
 					Name:           jwtConf.Name,
+					RoleClaim:      jwtConf.RoleClaim,
+					RoleMap:        jwtConf.RoleMap,
 					ScopeClaim:     jwtConf.ScopeClaim,
 					Source:         ac.NewJWTSource(jwtConf.Cookie, jwtConf.Header),
 				})

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -352,12 +352,18 @@ required _label_.
 | `claims`               |object|-|Object with claims that must be given for a valid token (equals comparison with JWT payload).| The claim values are evaluated per request. | `claims = { pid = request.path_params.pid }` |
 | `required_claims`      |string|-|List of claim names that must be given for a valid token |-|`required_claims = ["role"]`|
 | `beta_scope_claim` |string|-|name of claim specifying the scope of token|The claim value must either be a string containing a space-separated list of scope values or a list of string scope values|`beta_scope_claim = "scope"`|
+| `beta_role_claim` |string|-|name of claim specifying the roles of the user represented by the token|The claim value must either be a string containing a space-separated list of role values or a list of string role values|`beta_role_claim = "role"`|
+| `beta_role_map` |string|-|mapping of roles to scope values|-|`beta_role_map = { role1 = ["scope1", "scope2"], role2 = ["scope3"] }`|
 | `jwks_url` | string | - | URI pointing to a set of [JSON Web Keys (RFC 7517)](https://datatracker.ietf.org/doc/html/rfc7517) | - | `jwks_url = "http://identityprovider:8080/jwks.json"` |
 | `jwks_ttl` | [duration](#duration) | `"1h"` | Time period the JWK set stays valid and may be cached. | - | `jwks_ttl = "1800s"` |
 | `backend`  | string| - | [backend reference](#backend-block) for enhancing JWKS requests| - | `backend = "jwks_backend"` |
 
 If the key to verify the signatures of tokens does not change over time, it should be specified via either `key` or `key_file` (together with `signature_algorithm`).
 Otherwise, a JSON web key set should be referenced via `jwks_url`; in this case, the tokens need a `kid` header.
+
+A JWT access control configured by this block can extract scope values from
+* the value of the claim specified by `beta_scope_claim` and
+* the result of mapping the value of the claim specified by `beta_role_claim` using the `beta_role_map`.
 
 The `jwt` block may also be referenced by the [`jwt_sign()` function](#functions), if it has a `signing_ttl` defined. For `HS*` algorithms the signing key is taken from `key`/`key_file`, for `RS*` algorithms, `signing_key` or `signing_key_file` have to be specified.
 

--- a/server/http_integration_test.go
+++ b/server/http_integration_test.go
@@ -2967,6 +2967,7 @@ func Test_Scope(t *testing.T) {
 
 	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
 		"scp": "a",
+		"rl":  "r1",
 	})
 	token, tokenErr := tok.SignedString([]byte("asdf"))
 	h.Must(tokenErr)
@@ -2982,12 +2983,18 @@ func Test_Scope(t *testing.T) {
 	}
 
 	for _, tc := range []testCase{
-		{"unauthorized", http.MethodGet, "/foo", false, http.StatusUnauthorized, "access control error: myjwt: token required", "jwt_token_missing"},
-		{"sufficient scope", http.MethodGet, "/foo", true, http.StatusNoContent, "", ""},
-		{"additional scope required: insufficient scope", http.MethodPost, "/foo", true, http.StatusForbidden, `access control error: scope: required scope "foo" not granted`, "beta_insufficient_scope"},
-		{"operation not permitted", http.MethodDelete, "/foo", true, http.StatusForbidden, "access control error: scope: operation DELETE not permitted", "beta_operation_denied"},
-		{"additional scope required by *: insufficient scope", http.MethodGet, "/bar", true, http.StatusForbidden, `access control error: scope: required scope "more" not granted`, "beta_insufficient_scope"},
-		{"no additional scope required: sufficient scope", http.MethodDelete, "/bar", true, http.StatusNoContent, "", ""},
+		{"by scope: unauthorized", http.MethodGet, "/scope/foo", false, http.StatusUnauthorized, "access control error: scoped_jwt: token required", "jwt_token_missing"},
+		{"by scope: sufficient scope", http.MethodGet, "/scope/foo", true, http.StatusNoContent, "", ""},
+		{"by scope: additional scope required: insufficient scope", http.MethodPost, "/scope/foo", true, http.StatusForbidden, `access control error: scope: required scope "foo" not granted`, "beta_insufficient_scope"},
+		{"by scope: operation not permitted", http.MethodDelete, "/scope/foo", true, http.StatusForbidden, "access control error: scope: operation DELETE not permitted", "beta_operation_denied"},
+		{"by scope: additional scope required by *: insufficient scope", http.MethodGet, "/scope/bar", true, http.StatusForbidden, `access control error: scope: required scope "more" not granted`, "beta_insufficient_scope"},
+		{"by scope: no additional scope required: sufficient scope", http.MethodDelete, "/scope/bar", true, http.StatusNoContent, "", ""},
+		{"by role: unauthorized", http.MethodGet, "/role/foo", false, http.StatusUnauthorized, "access control error: roled_jwt: token required", "jwt_token_missing"},
+		{"by role: sufficient scope", http.MethodGet, "/role/foo", true, http.StatusNoContent, "", ""},
+		{"by role: additional scope required: insufficient scope", http.MethodPost, "/role/foo", true, http.StatusForbidden, `access control error: scope: required scope "foo" not granted`, "beta_insufficient_scope"},
+		{"by role: operation not permitted", http.MethodDelete, "/role/foo", true, http.StatusForbidden, "access control error: scope: operation DELETE not permitted", "beta_operation_denied"},
+		{"by role: additional scope required by *: insufficient scope", http.MethodGet, "/role/bar", true, http.StatusForbidden, `access control error: scope: required scope "more" not granted`, "beta_insufficient_scope"},
+		{"by role: no additional scope required: sufficient scope", http.MethodDelete, "/role/bar", true, http.StatusNoContent, "", ""},
 	} {
 		t.Run(fmt.Sprintf("%s_%s_%s", tc.name, tc.operation, tc.path), func(subT *testing.T) {
 			helper := test.New(subT)
@@ -3003,7 +3010,7 @@ func Test_Scope(t *testing.T) {
 			helper.Must(err)
 
 			if res.StatusCode != tc.status {
-				t.Errorf("%q: expected Status %d, got: %d", tc.name, tc.status, res.StatusCode)
+				t.Errorf("expected Status %d, got: %d", tc.status, res.StatusCode)
 				return
 			}
 

--- a/server/testdata/integration/config/09_couper.hcl
+++ b/server/testdata/integration/config/09_couper.hcl
@@ -1,6 +1,30 @@
 server "scoped jwt" {
   api {
-    access_control = ["myjwt"]
+    base_path = "/scope"
+    access_control = ["scoped_jwt"]
+    beta_scope = "a"
+    endpoint "/foo" {
+      beta_scope = {
+        get = ""
+        post = "foo"
+      }
+      response {
+        status = 204
+      }
+    }
+    endpoint "/bar" {
+      beta_scope = {
+        delete = ""
+        "*" = "more"
+      }
+      response {
+        status = 204
+      }
+    }
+  }
+  api {
+    base_path = "/role"
+    access_control = ["roled_jwt"]
     beta_scope = "a"
     endpoint "/foo" {
       beta_scope = {
@@ -23,10 +47,19 @@ server "scoped jwt" {
   }
 }
 definitions {
-  jwt "myjwt" {
+  jwt "scoped_jwt" {
     header = "authorization"
     signature_algorithm = "HS256"
     key = "asdf"
     beta_scope_claim = "scp"
+  }
+  jwt "roled_jwt" {
+    header = "authorization"
+    signature_algorithm = "HS256"
+    key = "asdf"
+    beta_role_claim = "rl"
+    beta_role_map = {
+      "r1" = ["a", "b"]
+    }
   }
 }


### PR DESCRIPTION
Map roles from a JWT to scope values with
```hcl
jwt "role_jwt" {
  ...
  beta_role_claim = "roles"
  beta_role_map = {
    admin = ["read", "write", "delete"]
    user = ["read"]
    developer = ["read", "write"]
  }
}
```
so that e.g. a JWT with
```json
{
  ...
  "roles": "user developer"
}
```
or
```json
{
  ...
  "roles": ["user", "developer"]
}
```

will yield the scope values `read` and `write`.

---
<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>
