### PR TITLE
Add service_name option and prometheus collector wrapper

### DIFF
--- a/command/run.go
+++ b/command/run.go
@@ -50,12 +50,13 @@ func NewRun(ctx context.Context) *Run {
 	set.StringVar(&settings.RequestIDClientHeader, "request-id-client-header", settings.RequestIDClientHeader, "-request-id-client-header Couper-Request-ID")
 	set.StringVar(&settings.RequestIDFormat, "request-id-format", settings.RequestIDFormat, "-request-id-format uuid4")
 	set.StringVar(&settings.SecureCookies, "secure-cookies", settings.SecureCookies, "-secure-cookies strip")
-	set.BoolVar(&settings.TelemetryMetrics, "beta-metrics", settings.TelemetryMetrics, "-metrics")
-	set.IntVar(&settings.TelemetryMetricsPort, "beta-metrics-port", settings.TelemetryMetricsPort, "-metrics-port 9090")
-	set.StringVar(&settings.TelemetryMetricsEndpoint, "beta-metrics-endpoint", settings.TelemetryMetricsEndpoint, "-metrics-endpoint [host:port]")
-	set.StringVar(&settings.TelemetryMetricsExporter, "beta-metrics-exporter", settings.TelemetryMetricsExporter, "-metrics-exporter [name]")
+	set.BoolVar(&settings.TelemetryMetrics, "beta-metrics", settings.TelemetryMetrics, "-beta-metrics")
+	set.IntVar(&settings.TelemetryMetricsPort, "beta-metrics-port", settings.TelemetryMetricsPort, "-beta-metrics-port 9090")
+	set.StringVar(&settings.TelemetryMetricsEndpoint, "beta-metrics-endpoint", settings.TelemetryMetricsEndpoint, "-beta-metrics-endpoint [host:port]")
+	set.StringVar(&settings.TelemetryMetricsExporter, "beta-metrics-exporter", settings.TelemetryMetricsExporter, "-beta-metrics-exporter [name]")
+	set.StringVar(&settings.TelemetryServiceName, "beta-service-name", settings.TelemetryServiceName, "-beta-service-name [name]")
 	set.BoolVar(&settings.TelemetryTraces, "beta-traces", settings.TelemetryTraces, "-traces")
-	set.StringVar(&settings.TelemetryTracesEndpoint, "beta-traces-endpoint", settings.TelemetryTracesEndpoint, "-traces-endpoint [host:port]")
+	set.StringVar(&settings.TelemetryTracesEndpoint, "beta-traces-endpoint", settings.TelemetryTracesEndpoint, "-beta-traces-endpoint [host:port]")
 	return &Run{
 		context:  ctx,
 		flagSet:  set,
@@ -123,6 +124,7 @@ func (r *Run) Execute(args Args, config *config.Couper, logEntry *logrus.Entry) 
 		MetricsEndpoint:      r.settings.TelemetryMetricsEndpoint,
 		MetricsExporter:      r.settings.TelemetryMetricsExporter,
 		MetricsPort:          r.settings.TelemetryMetricsPort,
+		ServiceName:          r.settings.TelemetryServiceName,
 		Traces:               r.settings.TelemetryTraces,
 		TracesEndpoint:       r.settings.TelemetryTracesEndpoint,
 	}, logEntry)

--- a/config/settings.go
+++ b/config/settings.go
@@ -64,6 +64,7 @@ var DefaultSettings = Settings{
 	TelemetryMetricsEndpoint: otelCollectorEndpoint,
 	TelemetryMetricsExporter: "prometheus",
 	TelemetryMetricsPort:     9090, // default prometheus port
+	TelemetryServiceName:     "couper",
 	TelemetryTracesEndpoint:  otelCollectorEndpoint,
 	XForwardedHost:           false,
 
@@ -90,9 +91,10 @@ type Settings struct {
 	SecureCookies             string   `hcl:"secure_cookies,optional"`
 	TLSDevProxy               List     `hcl:"https_dev_proxy,optional"`
 	TelemetryMetrics          bool     `hcl:"beta_metrics,optional"`
-	TelemetryMetricsPort      int      `hcl:"beta_metrics_port,optional"`
 	TelemetryMetricsEndpoint  string   `hcl:"beta_metrics_endpoint,optional"`
 	TelemetryMetricsExporter  string   `hcl:"beta_metrics_exporter,optional"`
+	TelemetryMetricsPort      int      `hcl:"beta_metrics_port,optional"`
+	TelemetryServiceName      string   `hcl:"beta_service_name,optional"`
 	TelemetryTraces           bool     `hcl:"beta_traces,optional"`
 	TelemetryTracesEndpoint   string   `hcl:"beta_traces_endpoint,optional"`
 	XForwardedHost            bool     `hcl:"xfh,optional"`

--- a/telemetry/collector.go
+++ b/telemetry/collector.go
@@ -1,0 +1,56 @@
+package telemetry
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+var _ prometheus.Collector = &ServiceNameCollector{}
+
+type ServiceNameCollector struct {
+	labelPair *dto.LabelPair
+	wrapped   prometheus.Collector
+}
+
+func NewServiceNameCollector(name string, coll prometheus.Collector) prometheus.Collector {
+	serviceName := "service_name"
+	return &ServiceNameCollector{
+		labelPair: &dto.LabelPair{Name: &serviceName, Value: &name},
+		wrapped:   coll,
+	}
+}
+
+func (s *ServiceNameCollector) Describe(descs chan<- *prometheus.Desc) {
+	s.wrapped.Describe(descs)
+}
+
+func (s *ServiceNameCollector) Collect(metrics chan<- prometheus.Metric) {
+	metricsCh := make(chan prometheus.Metric, 10)
+	go func() {
+		s.wrapped.Collect(metricsCh)
+		close(metricsCh)
+	}()
+	for m := range metricsCh {
+		metrics <- &WrappedMetrics{
+			inner:     m,
+			labelPair: s.labelPair,
+		}
+	}
+}
+
+var _ prometheus.Metric = &WrappedMetrics{}
+
+type WrappedMetrics struct {
+	inner     prometheus.Metric
+	labelPair *dto.LabelPair
+}
+
+func (w *WrappedMetrics) Desc() *prometheus.Desc {
+	return w.inner.Desc()
+}
+
+func (w *WrappedMetrics) Write(metric *dto.Metric) error {
+	err := w.inner.Write(metric)
+	metric.Label = append(metric.Label, w.labelPair)
+	return err
+}

--- a/telemetry/options.go
+++ b/telemetry/options.go
@@ -8,6 +8,7 @@ type Options struct {
 	MetricsEndpoint      string
 	MetricsExporter      string
 	MetricsPort          int
+	ServiceName          string
 	Traces               bool
 	TracesEndpoint       string
 }


### PR DESCRIPTION
to add labels for internal (go/runtime)collectors too

Background: Selecting metrics by job or k8s namespace could not be enough, this pr makes the service_name configurable and also adds them to go_* metrics.

---
<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>
