### PR TITLE
CORS and access controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Unreleased changes are available as `avenga/couper:edge` container.
 * **Fixed**
   * Handling of [`accept_forwarded_url`](./docs/REFERENCE.md#settings-block) "host" if `H-Forwarded-Host` request header field contains a port ([#360](https://github.com/avenga/couper/pull/360))
   * Setting `Vary` response header fields for [CORS](./doc/REFERENCE.md#cors-block) ([#362](https://github.com/avenga/couper/pull/362))
+  * [CORS](./doc/REFERENCE.md#cors-block) preflight requests are not blocked by access controls any more ([#366](https://github.com/avenga/couper/pull/366))
 
 ---
 

--- a/config/runtime/server.go
+++ b/config/runtime/server.go
@@ -152,13 +152,6 @@ func NewServerConfiguration(conf *config.Couper, log *logrus.Entry, memStore *ca
 				return nil, err
 			}
 
-			corsOptions, cerr := middleware.NewCORSOptions(whichCORS(srvConf, srvConf.Spa))
-			if cerr != nil {
-				return nil, cerr
-			}
-
-			spaHandler = middleware.NewCORSHandler(corsOptions, spaHandler)
-
 			spaHandler, err = configureProtectedHandler(accessControls, confCtx,
 				config.NewAccessControl(srvConf.AccessControl, srvConf.DisableAccessControl),
 				config.NewAccessControl(srvConf.Spa.AccessControl, srvConf.Spa.DisableAccessControl),
@@ -172,6 +165,13 @@ func NewServerConfiguration(conf *config.Couper, log *logrus.Entry, memStore *ca
 			if err != nil {
 				return nil, err
 			}
+
+			corsOptions, cerr := middleware.NewCORSOptions(whichCORS(srvConf, srvConf.Spa))
+			if cerr != nil {
+				return nil, cerr
+			}
+
+			spaHandler = middleware.NewCORSHandler(corsOptions, spaHandler)
 
 			for _, spaPath := range srvConf.Spa.Paths {
 				err = setRoutesFromHosts(serverConfiguration, portsHosts, path.Join(serverOptions.SPABasePath, spaPath), spaHandler, spa)
@@ -191,13 +191,6 @@ func NewServerConfiguration(conf *config.Couper, log *logrus.Entry, memStore *ca
 				return nil, err
 			}
 
-			corsOptions, cerr := middleware.NewCORSOptions(whichCORS(srvConf, srvConf.Files))
-			if cerr != nil {
-				return nil, cerr
-			}
-
-			fileHandler = middleware.NewCORSHandler(corsOptions, fileHandler)
-
 			fileHandler, err = configureProtectedHandler(accessControls, confCtx,
 				config.NewAccessControl(srvConf.AccessControl, srvConf.DisableAccessControl),
 				config.NewAccessControl(srvConf.Files.AccessControl, srvConf.Files.DisableAccessControl),
@@ -211,6 +204,13 @@ func NewServerConfiguration(conf *config.Couper, log *logrus.Entry, memStore *ca
 			if err != nil {
 				return nil, err
 			}
+
+			corsOptions, cerr := middleware.NewCORSOptions(whichCORS(srvConf, srvConf.Files))
+			if cerr != nil {
+				return nil, cerr
+			}
+
+			fileHandler = middleware.NewCORSHandler(corsOptions, fileHandler)
 
 			err = setRoutesFromHosts(serverConfiguration, portsHosts, serverOptions.FilesBasePath, fileHandler, files)
 			if err != nil {
@@ -266,13 +266,6 @@ func NewServerConfiguration(conf *config.Couper, log *logrus.Entry, memStore *ca
 				epHandler = handler.NewEndpoint(epOpts, log, modifier)
 			}
 
-			corsOptions, err := middleware.NewCORSOptions(whichCORS(srvConf, parentAPI))
-			if err != nil {
-				return nil, err
-			}
-
-			epHandler = middleware.NewCORSHandler(corsOptions, epHandler)
-
 			scopeMaps := []map[string]string{}
 			if parentAPI != nil {
 				apiScopeMap, err := seetie.ValueToScopeMap(parentAPI.Scope)
@@ -300,6 +293,13 @@ func NewServerConfiguration(conf *config.Couper, log *logrus.Entry, memStore *ca
 			if err != nil {
 				return nil, err
 			}
+
+			corsOptions, err := middleware.NewCORSOptions(whichCORS(srvConf, parentAPI))
+			if err != nil {
+				return nil, err
+			}
+
+			epHandler = middleware.NewCORSHandler(corsOptions, epHandler)
 
 			endpointHandlers[endpointConf] = epHandler
 			err = setRoutesFromHosts(serverConfiguration, portsHosts, pattern, endpointHandlers[endpointConf], kind)

--- a/config/runtime/server.go
+++ b/config/runtime/server.go
@@ -156,19 +156,19 @@ func NewServerConfiguration(conf *config.Couper, log *logrus.Entry, memStore *ca
 			if cerr != nil {
 				return nil, cerr
 			}
-			h := middleware.NewCORSHandler(corsOptions, spaHandler)
+
+			spaHandler = middleware.NewCORSHandler(corsOptions, spaHandler)
 
 			spaHandler, err = configureProtectedHandler(accessControls, confCtx,
 				config.NewAccessControl(srvConf.AccessControl, srvConf.DisableAccessControl),
 				config.NewAccessControl(srvConf.Spa.AccessControl, srvConf.Spa.DisableAccessControl),
 				&protectedOptions{
 					epOpts:       &handler.EndpointOptions{Error: serverOptions.ServerErrTpl},
-					handler:      h,
+					handler:      spaHandler,
 					memStore:     memStore,
 					proxyFromEnv: conf.Settings.NoProxyFromEnv,
 					srvOpts:      serverOptions,
 				}, nil, log)
-
 			if err != nil {
 				return nil, err
 			}
@@ -182,9 +182,13 @@ func NewServerConfiguration(conf *config.Couper, log *logrus.Entry, memStore *ca
 		}
 
 		if srvConf.Files != nil {
-			fileHandler, ferr := handler.NewFile(srvConf.Files.DocumentRoot, serverOptions, []hcl.Body{srvConf.Files.Remain, srvConf.Remain})
-			if ferr != nil {
-				return nil, ferr
+			var (
+				fileHandler http.Handler
+				err         error
+			)
+			fileHandler, err = handler.NewFile(srvConf.Files.DocumentRoot, serverOptions, []hcl.Body{srvConf.Files.Remain, srvConf.Remain})
+			if err != nil {
+				return nil, err
 			}
 
 			corsOptions, cerr := middleware.NewCORSOptions(whichCORS(srvConf, srvConf.Files))
@@ -192,24 +196,23 @@ func NewServerConfiguration(conf *config.Couper, log *logrus.Entry, memStore *ca
 				return nil, cerr
 			}
 
-			h := middleware.NewCORSHandler(corsOptions, fileHandler)
+			fileHandler = middleware.NewCORSHandler(corsOptions, fileHandler)
 
-			protectedFileHandler, err := configureProtectedHandler(accessControls, confCtx,
+			fileHandler, err = configureProtectedHandler(accessControls, confCtx,
 				config.NewAccessControl(srvConf.AccessControl, srvConf.DisableAccessControl),
 				config.NewAccessControl(srvConf.Files.AccessControl, srvConf.Files.DisableAccessControl),
 				&protectedOptions{
 					epOpts:       &handler.EndpointOptions{Error: serverOptions.FilesErrTpl},
-					handler:      h,
+					handler:      fileHandler,
 					memStore:     memStore,
 					proxyFromEnv: conf.Settings.NoProxyFromEnv,
 					srvOpts:      serverOptions,
 				}, nil, log)
-
 			if err != nil {
 				return nil, err
 			}
 
-			err = setRoutesFromHosts(serverConfiguration, portsHosts, serverOptions.FilesBasePath, protectedFileHandler, files)
+			err = setRoutesFromHosts(serverConfiguration, portsHosts, serverOptions.FilesBasePath, fileHandler, files)
 			if err != nil {
 				return nil, err
 			}
@@ -238,10 +241,6 @@ func NewServerConfiguration(conf *config.Couper, log *logrus.Entry, memStore *ca
 			}
 			endpointPatterns[cleanPattern] = true
 
-			corsOptions, err := middleware.NewCORSOptions(whichCORS(srvConf, parentAPI))
-			if err != nil {
-				return nil, err
-			}
 			epOpts, err := newEndpointOptions(
 				confCtx, endpointConf, parentAPI, serverOptions,
 				log, conf.Settings.NoProxyFromEnv, memStore,
@@ -260,13 +259,20 @@ func NewServerConfiguration(conf *config.Couper, log *logrus.Entry, memStore *ca
 			}
 			epOpts.LogHandlerKind = kind.String()
 
-			var protectedHandler http.Handler
+			var epHandler http.Handler
 			if parentAPI != nil && parentAPI.CatchAllEndpoint == endpointConf {
-				protectedHandler = epOpts.Error.ServeError(errors.RouteNotFound)
+				epHandler = epOpts.Error.ServeError(errors.RouteNotFound)
 			} else {
-				epHandler := handler.NewEndpoint(epOpts, log, modifier)
-				protectedHandler = middleware.NewCORSHandler(corsOptions, epHandler)
+				epHandler = handler.NewEndpoint(epOpts, log, modifier)
 			}
+
+			corsOptions, err := middleware.NewCORSOptions(whichCORS(srvConf, parentAPI))
+			if err != nil {
+				return nil, err
+			}
+
+			epHandler = middleware.NewCORSHandler(corsOptions, epHandler)
+
 			scopeMaps := []map[string]string{}
 			if parentAPI != nil {
 				apiScopeMap, err := seetie.ValueToScopeMap(parentAPI.Scope)
@@ -282,11 +288,11 @@ func NewServerConfiguration(conf *config.Couper, log *logrus.Entry, memStore *ca
 			scopeMaps = append(scopeMaps, endpointScopeMap)
 			scopeControl := ac.NewScopeControl(scopeMaps)
 			accessControl := newAC(srvConf, parentAPI)
-			endpointHandlers[endpointConf], err = configureProtectedHandler(accessControls, confCtx, accessControl,
+			epHandler, err = configureProtectedHandler(accessControls, confCtx, accessControl,
 				config.NewAccessControl(endpointConf.AccessControl, endpointConf.DisableAccessControl),
 				&protectedOptions{
 					epOpts:       epOpts,
-					handler:      protectedHandler,
+					handler:      epHandler,
 					memStore:     memStore,
 					proxyFromEnv: conf.Settings.NoProxyFromEnv,
 					srvOpts:      serverOptions,
@@ -295,6 +301,7 @@ func NewServerConfiguration(conf *config.Couper, log *logrus.Entry, memStore *ca
 				return nil, err
 			}
 
+			endpointHandlers[endpointConf] = epHandler
 			err = setRoutesFromHosts(serverConfiguration, portsHosts, pattern, endpointHandlers[endpointConf], kind)
 			if err != nil {
 				return nil, err

--- a/handler/middleware/cors.go
+++ b/handler/middleware/cors.go
@@ -98,10 +98,13 @@ func (c *CORS) isCorsPreflightRequest(req *http.Request) bool {
 }
 
 func (c *CORS) setCorsRespHeaders(headers http.Header, req *http.Request) {
+	// see https://fetch.spec.whatwg.org/#http-responses
+	allowSpecificOrigin := false
 	if c.options.AllowsOrigin("*") && !c.options.AllowCredentials {
 		headers.Set("Access-Control-Allow-Origin", "*")
 	} else {
 		headers.Add("Vary", "Origin")
+		allowSpecificOrigin = true
 	}
 
 	if !c.isCorsRequest(req) {
@@ -113,10 +116,7 @@ func (c *CORS) setCorsRespHeaders(headers http.Header, req *http.Request) {
 		return
 	}
 
-	// see https://fetch.spec.whatwg.org/#http-responses
-	if c.options.AllowsOrigin("*") && !c.options.AllowCredentials {
-		headers.Set("Access-Control-Allow-Origin", "*")
-	} else {
+	if allowSpecificOrigin {
 		headers.Set("Access-Control-Allow-Origin", requestOrigin)
 	}
 

--- a/server/http_integration_test.go
+++ b/server/http_integration_test.go
@@ -3710,6 +3710,7 @@ func TestCORS_Configuration(t *testing.T) {
 			acao, acaoExists := res.Header["Access-Control-Allow-Origin"]
 			acam, acamExists := res.Header["Access-Control-Allow-Methods"]
 			acah, acahExists := res.Header["Access-Control-Allow-Headers"]
+			acac, acacExists := res.Header["Access-Control-Allow-Credentials"]
 			if tc.expAllowed {
 				if !acaoExists || acao[0] != tc.origin {
 					subT.Errorf("Expected allowed origin, got: %v", acao)
@@ -3720,6 +3721,9 @@ func TestCORS_Configuration(t *testing.T) {
 				if !acahExists || acah[0] != tc.expAllowedHeaders {
 					subT.Errorf("Expected allowed headers, got: %v", acah)
 				}
+				if !acacExists || acac[0] != "true" {
+					subT.Errorf("Expected allowed credentials, got: %v", acac)
+				}
 			} else {
 				if acaoExists {
 					subT.Errorf("Expected not allowed origin, got: %v", acao)
@@ -3729,6 +3733,9 @@ func TestCORS_Configuration(t *testing.T) {
 				}
 				if acahExists {
 					subT.Errorf("Expected not allowed headers, got: %v", acah)
+				}
+				if acacExists {
+					subT.Errorf("Expected not allowed credentials, got: %v", acac)
 				}
 			}
 			vary, varyExists := res.Header["Vary"]

--- a/server/http_integration_test.go
+++ b/server/http_integration_test.go
@@ -3701,8 +3701,12 @@ func TestCORS_Configuration(t *testing.T) {
 				subT.Fatalf("%q: expected Status %d, got: %d", tc.path, http.StatusNoContent, res.StatusCode)
 			}
 
-			if val, exist := res.Header["Access-Control-Allow-Origin"]; tc.expAllowedOrigin && (!exist || val[0] != tc.origin) {
-				subT.Errorf("Expected allowed origin resp, got: %v", val)
+			val, exist := res.Header["Access-Control-Allow-Origin"]
+			if tc.expAllowedOrigin && (!exist || val[0] != tc.origin) {
+				subT.Errorf("Expected allowed origin, got: %v", val)
+			}
+			if !tc.expAllowedOrigin && exist {
+				subT.Errorf("Expected not allowed origin, got: %v", val)
 			}
 		})
 	}

--- a/server/http_integration_test.go
+++ b/server/http_integration_test.go
@@ -3672,9 +3672,9 @@ func TestCORS_Configuration(t *testing.T) {
 	requestHeaders := "Authorization"
 
 	type testCase struct {
-		path             string
-		origin           string
-		expAllowed       bool
+		path              string
+		origin            string
+		expAllowed        bool
 		expAllowedMethods string
 		expAllowedHeaders string
 	}

--- a/server/http_integration_test.go
+++ b/server/http_integration_test.go
@@ -3677,15 +3677,16 @@ func TestCORS_Configuration(t *testing.T) {
 		expAllowed        bool
 		expAllowedMethods string
 		expAllowedHeaders string
+		expVary           string
 	}
 
 	for _, tc := range []testCase{
-		{"/06_couper.hcl", "a.com", true, requestMethod, requestHeaders},
-		{"/spa/", "b.com", true, requestMethod, requestHeaders},
-		{"/api/", "c.com", true, requestMethod, requestHeaders},
-		{"/06_couper.hcl", "no.com", false, "", ""},
-		{"/spa/", "", false, "", ""},
-		{"/api/", "no.com", false, "", ""},
+		{"/06_couper.hcl", "a.com", true, requestMethod, requestHeaders, "Origin,Access-Control-Request-Method,Access-Control-Request-Headers"},
+		{"/spa/", "b.com", true, requestMethod, requestHeaders, "Origin,Access-Control-Request-Method,Access-Control-Request-Headers"},
+		{"/api/", "c.com", true, requestMethod, requestHeaders, "Origin,Access-Control-Request-Method,Access-Control-Request-Headers"},
+		{"/06_couper.hcl", "no.com", false, "", "", "Origin"},
+		{"/spa/", "", false, "", "", "Origin"},
+		{"/api/", "no.com", false, "", "", "Origin"},
 	} {
 		t.Run(tc.path[1:], func(subT *testing.T) {
 			helper := test.New(subT)
@@ -3729,6 +3730,10 @@ func TestCORS_Configuration(t *testing.T) {
 				if acahExists {
 					subT.Errorf("Expected not allowed headers, got: %v", acah)
 				}
+			}
+			vary, varyExists := res.Header["Vary"]
+			if !varyExists || strings.Join(vary, ",") != tc.expVary {
+				subT.Errorf("Expected vary %q, got: %q", tc.expVary, strings.Join(vary, ","))
 			}
 		})
 	}

--- a/server/http_integration_test.go
+++ b/server/http_integration_test.go
@@ -3671,7 +3671,7 @@ func TestCORS_Configuration(t *testing.T) {
 	type testCase struct {
 		path             string
 		origin           string
-		expAllowedOrigin bool
+		expAllowed       bool
 	}
 
 	for _, tc := range []testCase{
@@ -3701,12 +3701,15 @@ func TestCORS_Configuration(t *testing.T) {
 				subT.Fatalf("%q: expected Status %d, got: %d", tc.path, http.StatusNoContent, res.StatusCode)
 			}
 
-			val, exist := res.Header["Access-Control-Allow-Origin"]
-			if tc.expAllowedOrigin && (!exist || val[0] != tc.origin) {
-				subT.Errorf("Expected allowed origin, got: %v", val)
-			}
-			if !tc.expAllowedOrigin && exist {
-				subT.Errorf("Expected not allowed origin, got: %v", val)
+			acao, acaoExists := res.Header["Access-Control-Allow-Origin"]
+			if tc.expAllowed {
+				if !acaoExists || acao[0] != tc.origin {
+					subT.Errorf("Expected allowed origin, got: %v", acao)
+				}
+			} else {
+				if acaoExists {
+					subT.Errorf("Expected not allowed origin, got: %v", acao)
+				}
 			}
 		})
 	}

--- a/server/testdata/integration/config/06_couper.hcl
+++ b/server/testdata/integration/config/06_couper.hcl
@@ -5,6 +5,7 @@ server "cors" {
     document_root = "./"
     cors {
       allowed_origins = "a.com"
+      allow_credentials = true
     }
   }
 
@@ -13,6 +14,7 @@ server "cors" {
     bootstrap_file = "06_couper.hcl"
     cors {
       allowed_origins = "b.com"
+      allow_credentials = true
     }
   }
 
@@ -20,6 +22,7 @@ server "cors" {
     base_path = "/api"
     cors {
       allowed_origins = "c.com"
+      allow_credentials = true
     }
     endpoint "/" {
       response {}

--- a/server/testdata/integration/config/06_couper.hcl
+++ b/server/testdata/integration/config/06_couper.hcl
@@ -1,4 +1,6 @@
 server "cors" {
+  access_control = ["ba"]
+
   files {
     document_root = "./"
     cors {
@@ -22,5 +24,11 @@ server "cors" {
     endpoint "/" {
       response {}
     }
+  }
+}
+definitions {
+  basic_auth "ba" {
+    user = "foo"
+    password = "asdf"
   }
 }


### PR DESCRIPTION
CORS is now handled before the access controls, so that preflight requests do not reach the access control. Non-preflight requests are passed to the access controls if the origin is allowed.

---
<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>
