### PR TITLE
Fix missing read error handling

### DIFF
--- a/handler/proxy.go
+++ b/handler/proxy.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/avenga/couper/config"
 	"github.com/avenga/couper/config/request"
+	"github.com/avenga/couper/errors"
 	"github.com/avenga/couper/eval"
 	"github.com/avenga/couper/handler/ascii"
 	"github.com/avenga/couper/handler/transport"
@@ -347,7 +348,7 @@ func copyBuffer(dst io.Writer, src io.Reader, buf []byte) (int64, error) {
 	for {
 		nr, rerr := src.Read(buf)
 		if rerr != nil && rerr != io.EOF && rerr != context.Canceled {
-			//p.logf("httputil: ReverseProxy read error during body copy: %v", rerr)
+			return 0, errors.Server.With(rerr).Message("read error during body copy")
 		}
 		if nr > 0 {
 			nw, werr := dst.Write(buf[:nr])


### PR DESCRIPTION
#375 introduced copyBuffer code skipped the error handling during copy.

---
<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>
