### PR TITLE
Numeric timings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Unreleased changes are available as `avenga/couper:edge` container.
 
 * **Changed**
   * [`server` block](./docs/REFERENCE.md#server-block) label is now optional, [`api` block](./docs/REFERENCE.md#api-block) may be labelled ([#358](https://github.com/avenga/couper/pull/358))
+  * Timings in logs are now numeric values ([#367](https://github.com/avenga/couper/issues/367))
 
 * **Fixed**
   * Handling of [`accept_forwarded_url`](./docs/REFERENCE.md#settings-block) "host" if `H-Forwarded-Host` request header field contains a port ([#360](https://github.com/avenga/couper/pull/360))

--- a/changelog_test.go
+++ b/changelog_test.go
@@ -45,5 +45,4 @@ func TestChangelog_Links(t *testing.T) {
 			t.Errorf("line %d: missing issue or pull-request link:\n\t%q", nr, string(line))
 		}
 	}
-
 }

--- a/logging/helper.go
+++ b/logging/helper.go
@@ -1,7 +1,6 @@
 package logging
 
 import (
-	"fmt"
 	"math"
 	"net"
 	"net/http"
@@ -30,10 +29,15 @@ func splitHostPort(hp string) (string, string) {
 	return host, port
 }
 
-func roundMS(d time.Duration) string {
-	const maxDuration time.Duration = 1<<63 - 1
+func roundMS(d time.Duration) float64 {
+	const (
+		maxDuration time.Duration = 1<<63 - 1
+		milliSecond float64       = float64(time.Millisecond)
+	)
+
 	if d == maxDuration {
-		return "0.0"
+		return 0.0
 	}
-	return fmt.Sprintf("%.3f", math.Round(float64(d)*1000)/1000/float64(time.Millisecond))
+
+	return math.Round((float64(d)/milliSecond)*1000) / 1000
 }

--- a/logging/helper_internal_test.go
+++ b/logging/helper_internal_test.go
@@ -1,0 +1,24 @@
+package logging
+
+import (
+	"testing"
+	"time"
+)
+
+func TestHelper_roundMS(t *testing.T) {
+	type testCase struct {
+		dur time.Duration
+		exp float64
+	}
+
+	for _, tc := range []testCase{
+		{1234567 * time.Nanosecond, 1.2350},
+		{123456 * time.Microsecond, 123.456},
+		{123456 * time.Microsecond, 123.456000},
+		{123 * time.Millisecond, 123.0},
+	} {
+		if got := roundMS(tc.dur); got != tc.exp {
+			t.Errorf("expected '%#v', got '%#v'", tc.exp, got)
+		}
+	}
+}


### PR DESCRIPTION
Timings are now convert to floats w/ 3 decimals instead of strings.

---
<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>
