### PR TITLE
Simplify/reduce ulimit info to file descriptors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Unreleased changes are available as `avenga/couper:edge` container.
 * **Added**
   * Register `default` function as `coalesce` alias ([#356](https://github.com/avenga/couper/pull/356))
   * New HCL function [`relative_url()`](./docs/REFERENCE.md#functions) ([#361](https://github.com/avenga/couper/pull/361))
-  * Log system resource limits at startup ([#334](https://github.com/avenga/couper/pull/334))
+  * Log file descriptor limit at startup ([#383](https://github.com/avenga/couper/pull/383))
 
 * **Changed**
   * [`server` block](./docs/REFERENCE.md#server-block) label is now optional, [`api` block](./docs/REFERENCE.md#api-block) may be labelled ([#358](https://github.com/avenga/couper/pull/358))


### PR DESCRIPTION
```
INFO[0000] ulimit: max open files 1024 (hard limit: 524288)  build=dev type=couper_daemon version=0
INFO[0000] couper is serving: 0.0.0.0:8081               build=dev type=couper_daemon version=0
```
---
<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>
