### PR TITLE
remove debug log field for body buffer state

### DIFF
--- a/handler/proxy.go
+++ b/handler/proxy.go
@@ -120,7 +120,8 @@ func (p *Proxy) RoundTrip(req *http.Request) (*http.Response, error) {
 	transport.RemoveConnectionHeaders(beresp.Header)
 	transport.RemoveHopHeaders(beresp.Header)
 
-	err = eval.ApplyResponseContext(req.Context(), p.context, beresp)
+	evalCtx := eval.ContextFromRequest(req)
+	err = eval.ApplyResponseContext(evalCtx.WithBeresps(beresp), p.context, beresp)
 
 	return beresp, err
 }

--- a/logging/upstream_log.go
+++ b/logging/upstream_log.go
@@ -13,7 +13,6 @@ import (
 	"github.com/avenga/couper/config/env"
 	"github.com/avenga/couper/config/request"
 	"github.com/avenga/couper/errors"
-	"github.com/avenga/couper/eval"
 	"github.com/avenga/couper/handler/validation"
 )
 
@@ -109,10 +108,6 @@ func (u *UpstreamLog) RoundTrip(req *http.Request) (*http.Response, error) {
 		if retries, ok := req.Context().Value(request.TokenRequestRetries).(uint8); ok && retries > 0 {
 			fields["token_request_retry"] = retries
 		}
-	}
-
-	if opt, ok := req.Context().Value(request.BufferOptions).(eval.BufferOption); ok {
-		fields["buffered"] = opt.GoString()
 	}
 
 	fields["status"] = 0

--- a/server/http_integration_test.go
+++ b/server/http_integration_test.go
@@ -139,12 +139,13 @@ func newCouperWithConfig(couperConfig *config.Couper, helper *test.Helper) (func
 	test.WaitForClosedPort(port)
 	waitForCh := make(chan struct{}, 1)
 	command.RunCmdTestCallback = func() {
-		close(waitForCh)
+		waitForCh <- struct{}{}
 	}
 	defer func() { command.RunCmdTestCallback = nil }()
 
 	go func() {
 		if err := command.NewRun(ctx).Execute([]string{couperConfig.Filename}, couperConfig, log.WithContext(ctx)); err != nil {
+			command.RunCmdTestCallback()
 			shutdownFn()
 			panic(err)
 		}

--- a/server/http_integration_test.go
+++ b/server/http_integration_test.go
@@ -2890,7 +2890,7 @@ func TestOpenAPIValidateRequestResponseBuffer(t *testing.T) {
 	}))
 	defer origin.Close()
 
-	shutdown, hook := newCouper("testdata/integration/validation/02_couper.hcl", helper)
+	shutdown, _ := newCouper("testdata/integration/validation/02_couper.hcl", helper)
 	defer shutdown()
 
 	req, err := http.NewRequest(http.MethodPost, "http://localhost:8080/buffer", bytes.NewBufferString(content))
@@ -2898,10 +2898,6 @@ func TestOpenAPIValidateRequestResponseBuffer(t *testing.T) {
 
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Origin", origin.URL)
-
-	for _, e := range hook.AllEntries() {
-		println(e.Message)
-	}
 
 	res, err := test.NewHTTPClient().Do(req)
 	helper.Must(err)

--- a/server/testdata/integration/api/13_couper.hcl
+++ b/server/testdata/integration/api/13_couper.hcl
@@ -1,12 +1,13 @@
 server "ws" {
   api {
-    endpoint "/upgrade" {
+    endpoint "/upgrade/**" {
       proxy {
         backend {
           origin = env.COUPER_TEST_BACKEND_ADDR
           # /ws path is a echo websocket upgrade handler at our test-backend
-          path = "/ws"
+          path = "/**"
         }
+
         websockets {
           set_request_headers = {
             Echo = "ECHO"
@@ -14,7 +15,15 @@ server "ws" {
 
           set_response_headers = {
             Abc = "123"
+            X-Upgrade-Body = request.body
+            X-Upgrade-Resp-Body = backend_responses.default.body # should not be set due to upgrade
           }
+        }
+
+        # affects both cases: upgrade and non 101
+        set_response_headers = {
+          X-Body = request.body
+          X-Resp-Body = backend_responses.default.body
         }
       }
     }

--- a/server/testdata/integration/validation/02_couper.hcl
+++ b/server/testdata/integration/validation/02_couper.hcl
@@ -1,0 +1,13 @@
+server {
+  endpoint "/buffer" {
+    proxy {
+      backend {
+        origin = request.headers.origin
+        openapi {
+          file = "02_schema.yaml"
+        }
+        timeout = "5s"
+      }
+    }
+  }
+}

--- a/server/testdata/integration/validation/02_schema.yaml
+++ b/server/testdata/integration/validation/02_schema.yaml
@@ -1,0 +1,18 @@
+openapi: '3'
+info:
+  title: 'Couper backend validation test'
+  version: 'v1.2.3'
+paths:
+  /buffer:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+        required: true
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object


### PR DESCRIPTION
Fixup for #375 . Removing introduced buffered log-field.

Add additional related tests regarding `websockets` and `openapi` block.

---
<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>
