### PR TITLE
Fix missing type checks while using index expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ Unreleased changes are available as `avenga/couper:edge` container.
   * Reduced memory usage for backend response bodies which just get piped to the client and are not required to be read by Couper due to a variable references ([#375](https://github.com/avenga/couper/pull/375))
     * However, if a huge message body is passed and additionally referenced via e.g. `json_body`, Couper may require a lot of memory for storing the data structure.
   * For each SAML attribute listed in [`array_attributes`](./docs/REFERENCE.md#saml-block) at least an empty array is created in `request.context.<label>.attributes.<name>` ([#369](https://github.com/avenga/couper/pull/369))
-  * Missing support for RelativeTraversalExpr, IndexExpr, UnaryOpExpr ([#389](https://github.com/avenga/couper/pull/389))
+  * HCL: Missing support for RelativeTraversalExpr, IndexExpr, UnaryOpExpr ([#389](https://github.com/avenga/couper/pull/389))
+  * HCL: Missing support for different variable index key types ([#391](https://github.com/avenga/couper/pull/391))
 
 ---
 

--- a/eval/value.go
+++ b/eval/value.go
@@ -112,7 +112,13 @@ func newLiteralValueExpr(ctx *hcl.EvalContext, exp hcl.Expression) hclsyntax.Exp
 		for p, part := range expr.Parts {
 			expr.Parts[p] = newLiteralValueExpr(ctx, part)
 		}
-		return expr
+
+		// "pre"-evaluate to be able to combine string expressions with empty strings on NilVal result.
+		c, _ := expr.Value(ctx)
+		if c.IsNull() {
+			return &hclsyntax.LiteralValueExpr{Val: emptyStringVal, SrcRange: expr.Range()}
+		}
+		return &hclsyntax.LiteralValueExpr{Val: c, SrcRange: expr.Range()}
 	case *hclsyntax.TemplateWrapExpr:
 		if val := newLiteralValueExpr(ctx, expr.Wrapped); val != nil {
 			expr.Wrapped = val

--- a/eval/value.go
+++ b/eval/value.go
@@ -110,12 +110,7 @@ func newLiteralValueExpr(ctx *hcl.EvalContext, exp hcl.Expression) hclsyntax.Exp
 		return expr
 	case *hclsyntax.TemplateExpr:
 		for p, part := range expr.Parts {
-			for _, v := range part.Variables() {
-				if traversalValue(ctx.Variables, v) == cty.NilVal {
-					expr.Parts[p] = &hclsyntax.LiteralValueExpr{Val: emptyStringVal, SrcRange: v.SourceRange()}
-					break
-				}
-			}
+			expr.Parts[p] = newLiteralValueExpr(ctx, part)
 		}
 		return expr
 	case *hclsyntax.TemplateWrapExpr:

--- a/eval/value_test.go
+++ b/eval/value_test.go
@@ -55,12 +55,12 @@ func TestValue(t *testing.T) {
 			for _, attr := range attrs {
 				got, err := Value(evalCtx, attr.Expr)
 				if (err != nil) != tt.wantErr {
-					t.Errorf("Value() error = %v, wantErr %v", err, tt.wantErr)
-					t.Error(err.(errors.GoError).LogError())
+					st.Errorf("Value() error = %v, wantErr %v", err, tt.wantErr)
+					st.Error(err.(errors.GoError).LogError())
 					return
 				}
 				if !reflect.DeepEqual(got, tt.want) {
-					t.Errorf("Value() got = %v, want %v", got.GoString(), tt.want.GoString())
+					st.Errorf("Value() got = %v, want %v", got.GoString(), tt.want.GoString())
 				}
 			}
 		})

--- a/server/http_integration_test.go
+++ b/server/http_integration_test.go
@@ -3584,7 +3584,7 @@ func TestFunctions(t *testing.T) {
 	for _, tc := range []testCase{
 		{"merge", "/v1/merge", map[string]string{"X-Merged-1": "{\"foo\":[1,2]}", "X-Merged-2": "{\"bar\":[3,4]}", "X-Merged-3": "[\"a\",\"b\"]"}, http.StatusOK},
 		{"coalesce", "/v1/coalesce?q=a", map[string]string{"X-Coalesce-1": "/v1/coalesce", "X-Coalesce-2": "default", "X-Coalesce-3": "default", "X-Coalesce-4": "default"}, http.StatusOK},
-		{"default", "/v1/default?q=a", map[string]string{"X-Default-1": "/v1/default", "X-Default-2": "default", "X-Default-3": "default", "X-Default-4": "default", "X-Default-5": "prefix-default"}, http.StatusOK},
+		{"default", "/v1/default?q=a", map[string]string{"X-Default-1": "/v1/default", "X-Default-2": "default", "X-Default-3": "default", "X-Default-4": "default", "X-Default-5": "prefix-default", "X-Default-6": "default"}, http.StatusOK},
 	} {
 		t.Run(tc.path[1:], func(subT *testing.T) {
 			helper := test.New(subT)

--- a/server/http_integration_test.go
+++ b/server/http_integration_test.go
@@ -3584,7 +3584,7 @@ func TestFunctions(t *testing.T) {
 	for _, tc := range []testCase{
 		{"merge", "/v1/merge", map[string]string{"X-Merged-1": "{\"foo\":[1,2]}", "X-Merged-2": "{\"bar\":[3,4]}", "X-Merged-3": "[\"a\",\"b\"]"}, http.StatusOK},
 		{"coalesce", "/v1/coalesce?q=a", map[string]string{"X-Coalesce-1": "/v1/coalesce", "X-Coalesce-2": "default", "X-Coalesce-3": "default", "X-Coalesce-4": "default"}, http.StatusOK},
-		{"default", "/v1/default?q=a", map[string]string{"X-Default-1": "/v1/default", "X-Default-2": "default", "X-Default-3": "default", "X-Default-4": "default"}, http.StatusOK},
+		{"default", "/v1/default?q=a", map[string]string{"X-Default-1": "/v1/default", "X-Default-2": "default", "X-Default-3": "default", "X-Default-4": "default", "X-Default-5": "prefix-default"}, http.StatusOK},
 	} {
 		t.Run(tc.path[1:], func(subT *testing.T) {
 			helper := test.New(subT)

--- a/server/testdata/integration/functions/01_couper.hcl
+++ b/server/testdata/integration/functions/01_couper.hcl
@@ -30,6 +30,7 @@ server "api" {
           x-default-2 = default(request.cookies.undef, "default")
           x-default-3 = default(request.query.q[1], "default")
           x-default-4 = default(request.cookies.undef, request.query.q[1], "default", request.path)
+          x-default-5 = "prefix-${default(request.cookies.undef, "default")}" # template expr
         }
       }
     }

--- a/server/testdata/integration/functions/01_couper.hcl
+++ b/server/testdata/integration/functions/01_couper.hcl
@@ -31,6 +31,7 @@ server "api" {
           x-default-3 = default(request.query.q[1], "default")
           x-default-4 = default(request.cookies.undef, request.query.q[1], "default", request.path)
           x-default-5 = "prefix-${default(request.cookies.undef, "default")}" # template expr
+          x-default-6 = "${default(request.cookies.undef, "default")}" # template wrap expr
         }
       }
     }


### PR DESCRIPTION
This PR catches missing handling for index expression handling with different index key types.

---
<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>
