### PR TITLE
Ci platform build fixups

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -73,7 +73,7 @@ jobs:
       with:
         context: .
         labels: ${{ steps.meta.outputs.labels }}
-        tags: latest,${{ steps.meta.outputs.tags }}
+        tags: ${{ steps.meta.outputs.tags }}
         push: true
 
     - name: Docker Hub Description

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -73,7 +73,7 @@ jobs:
       with:
         context: .
         labels: ${{ steps.meta.outputs.labels }}
-        tags: ${{ steps.meta.outputs.tags }}
+        tags: latest,${{ steps.meta.outputs.tags }}
         push: true
 
     - name: Docker Hub Description

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   release:
-    types: [released]
+    types: [prereleased,released]
 
 jobs:
   releases-matrix:
@@ -12,22 +12,23 @@ jobs:
       VERSION_PACKAGE: 'github.com/avenga/couper/utils'
     strategy:
       matrix:
-        # build and publish in parallel: */amd64, */arm64
         goos: [linux, windows]
         goarch: [amd64, arm64]
-        exclude:
-          - goarch: arm64
-            goos: windows
     steps:
       - uses: actions/checkout@v2
+      - name: Set outputs
+        id: vars
+        run: |
+          echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+          echo "::set-output name=build_date::$(date +'%F')"
       - uses: wangyoucao577/go-release-action@v1.21
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }} # provided by github/actions
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}
           goversion: "1.17"
           binary_name: "couper"
-          ldflags: "-X ${VERSION_PACKAGE}.VersionName=`git describe --tags --abbrev=0 --exact-match || git symbolic-ref -q --short HEAD` -X ${VERSION_PACKAGE}.BuildName=`git rev-parse --short HEAD` -X ${VERSION_PACKAGE}.BuildDate=`date +'%F'`"
+          ldflags: "-X ${VERSION_PACKAGE}.VersionName=${GITHUB_REF_NAME} -X ${VERSION_PACKAGE}.BuildName=${{ steps.vars.outputs.sha_short }} -X ${VERSION_PACKAGE}.BuildDate=${{ steps.vars.outputs.build_date }}"
   macos:
     runs-on: macos-11
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Unreleased changes are available as `avenga/couper:edge` container.
 * **Changed**
   * Missing [scope or roles claims](./docs/REFERENCE.md#jwt-block), or scope or roles claim with unsupported values are now ignored instead of causing an error ([#380](https://github.com/avenga/couper/issues/380))
 
+* **Fixed**
+  * build-date configuration for binary and docker builds ([#396](https://github.com/avenga/couper/pull/396))
+  * exclude file descriptor limit startup-logs for windows ([#396](https://github.com/avenga/couper/pull/396)) ([#383](https://github.com/avenga/couper/pull/383))
+
 ---
 
 ## [1.6](https://github.com/avenga/couper/releases/tag/1.6)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Unreleased changes are available as `avenga/couper:edge` container.
 
 * **Fixed**
   * build-date configuration for binary and docker builds ([#396](https://github.com/avenga/couper/pull/396))
-  * exclude file descriptor limit startup-logs for windows ([#396](https://github.com/avenga/couper/pull/396)) ([#383](https://github.com/avenga/couper/pull/383))
+  * exclude file descriptor limit startup-logs for Windows ([#396](https://github.com/avenga/couper/pull/396), [#383](https://github.com/avenga/couper/pull/383))
 
 ---
 

--- a/command/run.go
+++ b/command/run.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -87,13 +86,11 @@ func (a AcceptForwardedValue) Set(s string) error {
 	return nil
 }
 
+var checkLimit func(entry *logrus.Entry)
+
 func (r *Run) Execute(args Args, config *config.Couper, logEntry *logrus.Entry) error {
-	lim := syscall.Rlimit{}
-	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &lim)
-	if err != nil {
-		logEntry.Warnf("ulimit: error retrieving file descriptor limit")
-	} else {
-		logEntry.Infof("ulimit: max open files: %d (hard limit: %d)", lim.Cur, lim.Max)
+	if checkLimit != nil {
+		checkLimit(logEntry)
 	}
 
 	r.settingsMu.Lock()
@@ -117,7 +114,7 @@ func (r *Run) Execute(args Args, config *config.Couper, logEntry *logrus.Entry) 
 
 	// Some remapping due to flag set pre-definition
 	env.Decode(r.settings)
-	err = r.settings.SetAcceptForwarded()
+	err := r.settings.SetAcceptForwarded()
 	if err != nil {
 		return err
 	}

--- a/command/run.go
+++ b/command/run.go
@@ -86,13 +86,10 @@ func (a AcceptForwardedValue) Set(s string) error {
 	return nil
 }
 
-var checkLimit func(entry *logrus.Entry)
+// limitFn depends on current OS, set via build flags
+var limitFn func(entry *logrus.Entry)
 
 func (r *Run) Execute(args Args, config *config.Couper, logEntry *logrus.Entry) error {
-	if checkLimit != nil {
-		checkLimit(logEntry)
-	}
-
 	r.settingsMu.Lock()
 	*r.settings = *config.Settings
 	r.settingsMu.Unlock()
@@ -142,6 +139,10 @@ func (r *Run) Execute(args Args, config *config.Couper, logEntry *logrus.Entry) 
 		return err
 	}
 	errors.SetLogger(logEntry)
+
+	if limitFn != nil {
+		limitFn(logEntry)
+	}
 
 	tlsDevPorts := make(server.TLSDevPorts)
 	for _, ports := range config.Settings.TLSDevProxy {

--- a/command/run_syscall.go
+++ b/command/run_syscall.go
@@ -1,4 +1,4 @@
-// +build linux darwin
+//go:build linux || darwin
 
 package command
 

--- a/command/run_syscall.go
+++ b/command/run_syscall.go
@@ -9,13 +9,15 @@ import (
 )
 
 func init() {
-	checkLimit = func(logEntry *logrus.Entry) {
-		lim := syscall.Rlimit{}
-		err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &lim)
-		if err != nil {
-			logEntry.Warnf("ulimit: error retrieving file descriptor limit")
-		} else {
-			logEntry.Infof("ulimit: max open files: %d (hard limit: %d)", lim.Cur, lim.Max)
-		}
+	limitFn = logRlimit
+}
+
+func logRlimit(logEntry *logrus.Entry) {
+	lim := syscall.Rlimit{}
+	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &lim)
+	if err != nil {
+		logEntry.Warnf("ulimit: error retrieving file descriptor limit")
+	} else {
+		logEntry.Infof("ulimit: max open files: %d (hard limit: %d)", lim.Cur, lim.Max)
 	}
 }

--- a/command/run_syscall.go
+++ b/command/run_syscall.go
@@ -1,0 +1,21 @@
+// +build linux darwin
+
+package command
+
+import (
+	"syscall"
+
+	"github.com/sirupsen/logrus"
+)
+
+func init() {
+	checkLimit = func(logEntry *logrus.Entry) {
+		lim := syscall.Rlimit{}
+		err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &lim)
+		if err != nil {
+			logEntry.Warnf("ulimit: error retrieving file descriptor limit")
+		} else {
+			logEntry.Infof("ulimit: max open files: %d (hard limit: %d)", lim.Cur, lim.Max)
+		}
+	}
+}

--- a/utils/version.go
+++ b/utils/version.go
@@ -3,7 +3,18 @@ package utils
 import "time"
 
 var (
-	BuildDate   = time.Now().Format("2006-01-02")
+	BuildDate   = ""
 	BuildName   = "dev"
 	VersionName = "0"
 )
+
+func init() {
+	if BuildDate == "" {
+		BuildDate = time.Now().Format("2006-01-02")
+	}
+
+	// strip out possible semver v
+	if len(VersionName) > 0 && VersionName[0] == 'v' {
+		VersionName = VersionName[1:]
+	}
+}


### PR DESCRIPTION
This will fix the build-date output from the version command for all builds.

Also excludes ulimit startup log for windows platform introduced in #383.

Some ci fixups regarding the build args

---
<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>
