### PR TITLE
Basic-Auth "user" accessable via request.context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Unreleased changes are available as `avenga/couper:edge` container.
 
 * **Added**
   * [`custom_log_fields`](./docs/LOGS.md#custom-logging) attribute to be able to describe a user defined map for `custom` log field enrichment ([#388](https://github.com/avenga/couper/pull/388))
+  * * The `user` as context variable from a [Basic Auth](./docs/REFERENCE.md#basic-auth-block) is now accessable via `request.context.<label>.user` for successfully authenticated requests ([#402](https://github.com/avenga/couper/pull/402))
 
 * **Changed**
   * Missing [scope or roles claims](./docs/REFERENCE.md#jwt-block), or scope or roles claim with unsupported values are now ignored instead of causing an error ([#380](https://github.com/avenga/couper/issues/380))

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -339,6 +339,8 @@ by `htpasswd_file` otherwise.
 | `realm`         | string | `""`    | The realm to be sent in a `WWW-Authenticate` response HTTP header field. | - | - |
 | `custom_log_fields` | map | - | Defines log fields for [Custom Logging](LOGS.md#custom-logging). | &#9888; Inherited by nested blocks. | - |
 
+The `user` is accessable via `request.context.<label>.user` for successfully authenticated requests.
+
 ### JWT Block
 
 The `jwt` block lets you configure JSON Web Token access control for your gateway.
@@ -608,9 +610,11 @@ defaults {
 
 The value of `context.<name>` depends on the type of block referenced by `<name>`.
 
-For a [JWT Block](#jwt-block), the variable contains claims from the JWT used for [Access Control](#access-control).
+For a [Basic Auth](#basic-auth-block) and successfully authenticated request the variable contains the `user` name.
 
-For a [SAML Block](#saml-block), the variable contains
+For a [JWT Block](#jwt-block) the variable contains claims from the JWT used for [Access Control](#access-control).
+
+For a [SAML Block](#saml-block) the variable contains
 
 - `sub`: the `NameID` of the SAML assertion
 - `exp`: optional expiration date (value of `SessionNotOnOrAfter` of the SAML assertion)

--- a/server/http_integration_test.go
+++ b/server/http_integration_test.go
@@ -3026,6 +3026,7 @@ func TestConfigBodyContentAccessControl(t *testing.T) {
 		{"/v5/not-exist", http.Header{}, http.StatusUnauthorized, "application/json", "access control error: ba1: credentials required"},
 		{"/superadmin", http.Header{"Authorization": []string{"Basic OmFzZGY="}, "Auth": []string{"ba1", "ba4"}}, http.StatusOK, "application/json", ""},
 		{"/superadmin", http.Header{}, http.StatusUnauthorized, "application/json", "access control error: ba1: credentials required"},
+		{"/ba5", http.Header{"Authorization": []string{"Basic VVNSOlBXRA=="}, "X-Ba-User": []string{"USR"}}, http.StatusOK, "application/json", ""},
 		{"/v4", http.Header{}, http.StatusUnauthorized, "text/html", "access control error: ba1: credentials required"},
 	} {
 		t.Run(tc.path[1:], func(subT *testing.T) {
@@ -3041,6 +3042,7 @@ func TestConfigBodyContentAccessControl(t *testing.T) {
 
 			res, err := client.Do(req)
 			helper.Must(err)
+			// t.Errorf(">>> %#v", res.Header)
 
 			message := getAccessControlMessages(hook)
 			if tc.wantErrLog == "" {

--- a/server/testdata/integration/config/03_couper.hcl
+++ b/server/testdata/integration/config/03_couper.hcl
@@ -84,6 +84,22 @@ server "acs" {
     }
   }
 
+  endpoint "/ba5" {
+    access_control = ["ba5"]
+    disable_access_control = ["ba1"]
+    proxy {
+      backend "test" {
+        set_request_headers = {
+          X-Ba-User = request.context.ba5.user
+          Authorization = request.headers.authorization # proxy blacklist
+        }
+        set_response_headers = {
+          X-BA-User = request.context.ba5.user
+        }
+      }
+    }
+  }
+
   endpoint "/jwt" {
     disable_access_control = ["ba1"]
     access_control = ["JWTToken"]
@@ -199,6 +215,10 @@ definitions {
   }
   basic_auth "ba4" {
     password = "asdf"
+  }
+  basic_auth "ba5" {
+    user     = "USR"
+    password = "PWD"
   }
   jwt "JWTToken" {
     header = "Authorization"


### PR DESCRIPTION
Basic-Auth "user" is accessable via request.context

---
<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>
