### PR TITLE
Sequence logged error type

### DIFF
--- a/handler/producer/sequence.go
+++ b/handler/producer/sequence.go
@@ -91,7 +91,9 @@ func (s Sequence) Produce(req *http.Request, results chan<- *Result) {
 		}
 
 		if lastResult.Err != nil {
-			lastResult.Err = errors.Sequence.With(lastResult.Err)
+			if _, ok := lastResult.Err.(*errors.Error); !ok {
+				lastResult.Err = errors.Sequence.With(lastResult.Err)
+			}
 			results <- lastResult
 			return
 		}

--- a/server/http_endpoints_test.go
+++ b/server/http_endpoints_test.go
@@ -597,8 +597,8 @@ func TestEndpointSequenceBackendTimeout(t *testing.T) {
 		helper.Must(err)
 	}
 
-	if res.StatusCode != http.StatusBadGateway {
-		t.Fatalf("Expected status 502, got: %d", res.StatusCode)
+	if res.StatusCode != http.StatusGatewayTimeout {
+		t.Fatalf("Expected status 504, got: %d", res.StatusCode)
 	}
 
 	time.Sleep(time.Second / 4)

--- a/server/testdata/endpoints/14_couper.hcl
+++ b/server/testdata/endpoints/14_couper.hcl
@@ -42,4 +42,34 @@ server { # error_handler
       }
     }
   }
+
+  endpoint "/not-ok-sequence" {
+    request "resolve" {
+      url = "${env.COUPER_TEST_BACKEND_ADDR}/anything"
+
+      expected_status = [200, 204]
+    }
+
+    custom_log_fields = {
+      beresp_res = backend_responses.resolve
+      beresp_def = backend_responses.default
+    }
+
+    proxy {
+      url = "${env.COUPER_TEST_BACKEND_ADDR}/reflect"
+      set_request_headers = {
+        x = backend_responses.resolve.headers.content-type
+      }
+      expected_status = [418]
+    }
+
+    error_handler "unexpected_status" {
+      response {
+        headers = {
+          x = backend_responses.default.headers.x
+        }
+        status = 418
+      }
+    }
+  }
 }


### PR DESCRIPTION
In a request sequence, an error is only wrapped as `sequence` error if it is not already a Couper error.

---
<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>
