### PR TITLE
JWT: Set `private` directive to the CC header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 Unreleased changes are available as `avenga/couper:edge` container.
 
+* **Added**
+  * `disable_private_caching` attribute for the [JWT Block](./docs/REFERENCE.md#jwt-block) ([#418](https://github.com/avenga/couper/pull/418))
+
 * **Fixed**
   * missing upstream log field value for `request.proto` ([#421](https://github.com/avenga/couper/pull/421))
 
@@ -38,7 +41,14 @@ On top of that the binary installation has been improved for [homebrew](https://
   * The access control for the OIDC redirect endpoint ([`oidc` block](./docs/REFERENCE.md#oidc-block)) now verifies ID token signatures ([#404](https://github.com/avenga/couper/pull/404))
   * `header = "Authorization"` is now the default token source for [JWT](./docs/REFERENCE.md#jwt-block) and may be omitted ([#413](https://github.com/avenga/couper/issues/413))
   * Improved the validation for unique keys in all map-attributes in the config ([#403](https://github.com/avenga/couper/pull/403))
+<<<<<<< HEAD
   * Missing [scope or roles claims](./docs/REFERENCE.md#jwt-block), or scope or roles claim with unsupported values are now ignored instead of causing an error ([#380](https://github.com/avenga/couper/issues/380))
+=======
+  * The access control for the OIDC redirect endpoint ([`oidc` block](./docs/REFERENCE.md#oidc-block)) now verifies ID token signatures ([#404](https://github.com/avenga/couper/pull/404))
+  * Unbeta [OIDC block](./docs/REFERENCE.md#oidc-block). The old block name is still usable with Couper 1.7, but will no longer work with Couper 1.8. ([#400](https://github.com/avenga/couper/pull/400))
+  * Unbeta the `oauth2_authorization_url()` and `oauth2_verifier()` [function](./docs/REFERENCE.md#functions). The prefix is changed from `beta_oauth_...` to `oauth2_...`. The old function names are still usable with Couper 1.7, but will no longer work with Couper 1.8. ([#400](https://github.com/avenga/couper/pull/400))
+  * Automatically add the `private` directive to the response `Cache-Control` HTTP header field value for all resources protected by [JWT](./docs/REFERENCE.md#jwt-block) ([#418](https://github.com/avenga/couper/pull/418))
+>>>>>>> 311ec60f... Changelog
 
 * **Fixed**
   * build-date configuration for binary and docker builds ([#396](https://github.com/avenga/couper/pull/396))

--- a/accesscontrol/ac.go
+++ b/accesscontrol/ac.go
@@ -33,6 +33,10 @@ type AccessControl interface {
 	Validate(req *http.Request) error
 }
 
+type DisablePrivateCaching interface {
+	DisablePrivateCaching() bool
+}
+
 type ProtectedHandler interface {
 	Child() http.Handler
 }
@@ -55,6 +59,14 @@ func (i ListItem) Validate(req *http.Request) error {
 
 func (i ListItem) ErrorHandler() http.Handler {
 	return i.controlErrHandler
+}
+
+func (i ListItem) DisablePrivateCaching() (bool, bool) {
+	if c, ok := i.control.(DisablePrivateCaching); ok {
+		return c.DisablePrivateCaching(), true
+	}
+
+	return false, false
 }
 
 func (f ValidateFunc) Validate(req *http.Request) error {

--- a/accesscontrol/ac.go
+++ b/accesscontrol/ac.go
@@ -61,12 +61,12 @@ func (i ListItem) ErrorHandler() http.Handler {
 	return i.controlErrHandler
 }
 
-func (i ListItem) DisablePrivateCaching() (bool, bool) {
+func (i ListItem) DisablePrivateCaching() bool {
 	if c, ok := i.control.(DisablePrivateCaching); ok {
-		return c.DisablePrivateCaching(), true
+		return c.DisablePrivateCaching()
 	}
-
-	return false, false
+	// not implemented, always disabled
+	return true
 }
 
 func (f ValidateFunc) Validate(req *http.Request) error {

--- a/accesscontrol/jwt.go
+++ b/accesscontrol/jwt.go
@@ -30,7 +30,10 @@ const (
 	Value
 )
 
-var _ AccessControl = &JWT{}
+var (
+	_ AccessControl         = &JWT{}
+	_ DisablePrivateCaching = &JWT{}
+)
 
 type (
 	JWTSourceType uint8
@@ -42,30 +45,32 @@ type (
 )
 
 type JWT struct {
-	algorithms     []acjwt.Algorithm
-	claims         hcl.Expression
-	claimsRequired []string
-	source         JWTSource
-	hmacSecret     []byte
-	name           string
-	pubKey         interface{}
-	rolesClaim     string
-	rolesMap       map[string][]string
-	scopeClaim     string
-	jwks           *jwk.JWKS
+	algorithms            []acjwt.Algorithm
+	claims                hcl.Expression
+	claimsRequired        []string
+	disablePrivateCaching bool
+	source                JWTSource
+	hmacSecret            []byte
+	name                  string
+	pubKey                interface{}
+	rolesClaim            string
+	rolesMap              map[string][]string
+	scopeClaim            string
+	jwks                  *jwk.JWKS
 }
 
 type JWTOptions struct {
-	Algorithm      string
-	Claims         hcl.Expression
-	ClaimsRequired []string
-	Name           string // TODO: more generic (validate)
-	RolesClaim     string
-	RolesMap       map[string][]string
-	ScopeClaim     string
-	Source         JWTSource
-	Key            []byte
-	JWKS           *jwk.JWKS
+	Algorithm             string
+	Claims                hcl.Expression
+	ClaimsRequired        []string
+	DisablePrivateCaching bool
+	Name                  string // TODO: more generic (validate)
+	RolesClaim            string
+	RolesMap              map[string][]string
+	ScopeClaim            string
+	Source                JWTSource
+	Key                   []byte
+	JWKS                  *jwk.JWKS
 }
 
 func NewJWTSource(cookie, header string, value hcl.Expression) JWTSource {
@@ -160,15 +165,20 @@ func newJWT(options *JWTOptions) (*JWT, error) {
 	}
 
 	jwtAC := &JWT{
-		claims:         options.Claims,
-		claimsRequired: options.ClaimsRequired,
-		name:           options.Name,
-		rolesClaim:     options.RolesClaim,
-		rolesMap:       options.RolesMap,
-		scopeClaim:     options.ScopeClaim,
-		source:         options.Source,
+		claims:                options.Claims,
+		claimsRequired:        options.ClaimsRequired,
+		disablePrivateCaching: options.DisablePrivateCaching,
+		name:                  options.Name,
+		rolesClaim:            options.RolesClaim,
+		rolesMap:              options.RolesMap,
+		scopeClaim:            options.ScopeClaim,
+		source:                options.Source,
 	}
 	return jwtAC, nil
+}
+
+func (j *JWT) DisablePrivateCaching() bool {
+	return j.disablePrivateCaching
 }
 
 // Validate reading the token from configured source and validates against the key.

--- a/config/ac_jwt.go
+++ b/config/ac_jwt.go
@@ -15,25 +15,26 @@ type Claims hcl.Expression
 // JWT represents the <JWT> object.
 type JWT struct {
 	ErrorHandlerSetter
-	BackendName        string              `hcl:"backend,optional"`
-	Claims             Claims              `hcl:"claims,optional"`
-	ClaimsRequired     []string            `hcl:"required_claims,optional"`
-	Cookie             string              `hcl:"cookie,optional"`
-	Header             string              `hcl:"header,optional"`
-	JWKsURL            string              `hcl:"jwks_url,optional"`
-	JWKsTTL            string              `hcl:"jwks_ttl,optional"`
-	Key                string              `hcl:"key,optional"`
-	KeyFile            string              `hcl:"key_file,optional"`
-	Name               string              `hcl:"name,label"`
-	Remain             hcl.Body            `hcl:",remain"`
-	RolesClaim         string              `hcl:"beta_roles_claim,optional"`
-	RolesMap           map[string][]string `hcl:"beta_roles_map,optional"`
-	ScopeClaim         string              `hcl:"beta_scope_claim,optional"`
-	SignatureAlgorithm string              `hcl:"signature_algorithm,optional"`
-	SigningKey         string              `hcl:"signing_key,optional"`
-	SigningKeyFile     string              `hcl:"signing_key_file,optional"`
-	SigningTTL         string              `hcl:"signing_ttl,optional"`
-	TokenValue         hcl.Expression      `hcl:"token_value,optional"`
+	BackendName           string              `hcl:"backend,optional"`
+	Claims                Claims              `hcl:"claims,optional"`
+	ClaimsRequired        []string            `hcl:"required_claims,optional"`
+	Cookie                string              `hcl:"cookie,optional"`
+	DisablePrivateCaching bool                `hcl:"disable_private_caching,optional"`
+	Header                string              `hcl:"header,optional"`
+	JWKsURL               string              `hcl:"jwks_url,optional"`
+	JWKsTTL               string              `hcl:"jwks_ttl,optional"`
+	Key                   string              `hcl:"key,optional"`
+	KeyFile               string              `hcl:"key_file,optional"`
+	Name                  string              `hcl:"name,label"`
+	Remain                hcl.Body            `hcl:",remain"`
+	RolesClaim            string              `hcl:"beta_roles_claim,optional"`
+	RolesMap              map[string][]string `hcl:"beta_roles_map,optional"`
+	ScopeClaim            string              `hcl:"beta_scope_claim,optional"`
+	SignatureAlgorithm    string              `hcl:"signature_algorithm,optional"`
+	SigningKey            string              `hcl:"signing_key,optional"`
+	SigningKeyFile        string              `hcl:"signing_key_file,optional"`
+	SigningTTL            string              `hcl:"signing_ttl,optional"`
+	TokenValue            hcl.Expression      `hcl:"token_value,optional"`
 
 	// Internally used
 	BodyContent *hcl.BodyContent

--- a/config/configload/endpoint.go
+++ b/config/configload/endpoint.go
@@ -2,11 +2,12 @@ package configload
 
 import (
 	"fmt"
+	"net/http"
+
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/zclconf/go-cty/cty"
-	"net/http"
 
 	"github.com/avenga/couper/config"
 	hclbody "github.com/avenga/couper/config/body"

--- a/config/runtime/server.go
+++ b/config/runtime/server.go
@@ -618,14 +618,15 @@ func configureAccessControls(conf *config.Couper, confCtx *hcl.EvalContext, log 
 				}
 
 				jwt, err = ac.NewJWTFromJWKS(&ac.JWTOptions{
-					Claims:         jwtConf.Claims,
-					ClaimsRequired: jwtConf.ClaimsRequired,
-					Name:           jwtConf.Name,
-					RolesClaim:     jwtConf.RolesClaim,
-					RolesMap:       jwtConf.RolesMap,
-					ScopeClaim:     jwtConf.ScopeClaim,
-					Source:         ac.NewJWTSource(jwtConf.Cookie, jwtConf.Header, jwtConf.TokenValue),
-					JWKS:           jwks,
+					Claims:                jwtConf.Claims,
+					ClaimsRequired:        jwtConf.ClaimsRequired,
+					DisablePrivateCaching: jwtConf.DisablePrivateCaching,
+					Name:                  jwtConf.Name,
+					RolesClaim:            jwtConf.RolesClaim,
+					RolesMap:              jwtConf.RolesMap,
+					ScopeClaim:            jwtConf.ScopeClaim,
+					Source:                ac.NewJWTSource(jwtConf.Cookie, jwtConf.Header, jwtConf.TokenValue),
+					JWKS:                  jwks,
 				})
 				if err != nil {
 					return nil, confErr.With(err)
@@ -637,15 +638,16 @@ func configureAccessControls(conf *config.Couper, confCtx *hcl.EvalContext, log 
 				}
 
 				jwt, err = ac.NewJWT(&ac.JWTOptions{
-					Algorithm:      jwtConf.SignatureAlgorithm,
-					Claims:         jwtConf.Claims,
-					ClaimsRequired: jwtConf.ClaimsRequired,
-					Key:            key,
-					Name:           jwtConf.Name,
-					RolesClaim:     jwtConf.RolesClaim,
-					RolesMap:       jwtConf.RolesMap,
-					ScopeClaim:     jwtConf.ScopeClaim,
-					Source:         ac.NewJWTSource(jwtConf.Cookie, jwtConf.Header, jwtConf.TokenValue),
+					Algorithm:             jwtConf.SignatureAlgorithm,
+					Claims:                jwtConf.Claims,
+					ClaimsRequired:        jwtConf.ClaimsRequired,
+					DisablePrivateCaching: jwtConf.DisablePrivateCaching,
+					Key:                   key,
+					Name:                  jwtConf.Name,
+					RolesClaim:            jwtConf.RolesClaim,
+					RolesMap:              jwtConf.RolesMap,
+					ScopeClaim:            jwtConf.ScopeClaim,
+					Source:                ac.NewJWTSource(jwtConf.Cookie, jwtConf.Header, jwtConf.TokenValue),
 				})
 
 				if err != nil {

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -358,6 +358,8 @@ Like all [Access Control](#access-control) types, the `jwt` block is defined in
 the [Definitions Block](#definitions-block) and can be referenced in all configuration blocks by its
 required _label_.
 
+Since responses from endpoints protected by JWT access controls are not publicly cacheable, a `Cache-Control: private` header field is added to the response, unless this feature is disabled with `disable_private_caching = true`.
+
 |Block name|Context|Label|Nested block(s)|
 | :-----------| :-----------| :-----------| :-----------|
 | `jwt`| [Definitions Block](#definitions-block)| &#9888; required | [JWKS `backend`](#backend-block), [Error Handler Block](ERRORS.md#error_handler-specification) |

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -379,6 +379,7 @@ required _label_.
 | `jwks_url` | string | - | URI pointing to a set of [JSON Web Keys (RFC 7517)](https://datatracker.ietf.org/doc/html/rfc7517) | - | `jwks_url = "http://identityprovider:8080/jwks.json"` |
 | `jwks_ttl` | [duration](#duration) | `"1h"` | Time period the JWK set stays valid and may be cached. | - | `jwks_ttl = "1800s"` |
 | `backend`  | string| - | [backend reference](#backend-block) for enhancing JWKS requests| - | `backend = "jwks_backend"` |
+| `disable_private_caching` | bool | `false` | If set to `true`, Couper does not add the `private` directive to the `Cache-Control` HTTP header field value. | - | - |
 
 The attributes `header`, `cookie` and `token_value` are mutually exclusive.
 If all three attributes are missing, `header = "Authorization"` will be implied, i.e. the token will be read from the incoming `Authorization` header.

--- a/handler/access_control.go
+++ b/handler/access_control.go
@@ -30,7 +30,7 @@ func (a *AccessControl) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	r, ok := rw.(*writer.Response)
 
 	for _, control := range a.acl {
-		if disable, implements := control.DisablePrivateCaching(); ok && implements && !disable {
+		if ok && !control.DisablePrivateCaching() {
 			r.AddPrivateCC()
 		}
 

--- a/server/testdata/integration/config/10_couper.hcl
+++ b/server/testdata/integration/config/10_couper.hcl
@@ -1,0 +1,53 @@
+server {
+  api {
+    base_path = "/cc-private"
+    access_control = ["jott"]
+
+    endpoint "/no-cc" {
+      response {
+        status = 204
+      }
+    }
+
+    endpoint "/cc-public" {
+      response {
+        status = 204
+        headers = {
+          cache-control = "public"
+        }
+      }
+    }
+  }
+  api {
+    base_path = "/no-cc-private"
+    access_control = ["jott-disable-cc-private"]
+
+    endpoint "/no-cc" {
+      response {
+        status = 204
+      }
+    }
+
+    endpoint "/cc-public" {
+      response {
+        status = 204
+        headers = {
+          cache-control = "public"
+        }
+      }
+    }
+  }
+}
+
+definitions {
+  jwt "jott" {
+    signature_algorithm = "HS256"
+    key = "asdf"
+  }
+
+  jwt "jott-disable-cc-private" {
+    signature_algorithm = "HS256"
+    key = "asdf"
+    disable_private_caching = true
+  }
+}

--- a/server/writer/response.go
+++ b/server/writer/response.go
@@ -48,6 +48,8 @@ type Response struct {
 	// modifier
 	evalCtx  *hcl.EvalContext
 	modifier []hcl.Body
+	// security
+	addPrivateCC bool
 }
 
 // NewResponseWriter creates a new Response object.
@@ -135,6 +137,11 @@ func (r *Response) WriteHeader(statusCode int) {
 	r.configureHeader()
 	r.applyModifier()
 
+	// !!! Execute after modifier !!!
+	if r.addPrivateCC {
+		r.Header().Add("Cache-Control", "private")
+	}
+
 	if statusCode == 0 {
 		r.rw.Header().Set(errors.HeaderErrorCode, errors.Server.Error())
 		statusCode = errors.Server.HTTPStatus()
@@ -180,6 +187,10 @@ func (r *Response) StatusCode() int {
 
 func (r *Response) WrittenBytes() int {
 	return r.bytesWritten
+}
+
+func (r *Response) AddPrivateCC() {
+	r.addPrivateCC = true
 }
 
 func (r *Response) AddModifier(evalCtx *hcl.EvalContext, modifier ...hcl.Body) {


### PR DESCRIPTION
Automatically add the `private` directive to the response `Cache-Control` HTTP header field value for all resources protected by JWT.

---
<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>
