### PR TITLE
fix: missing `request.proto` for upstream logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ On top of that the binary installation has been improved for [homebrew](https://
   * panic while accessing primitive variables with a key ([#377](https://github.com/avenga/couper/issues/377))
   * [`default()`](./docs/REFERENCE.md#functions) function continues to the next fallback value if this is a string type and an argument evaluates to an empty string ([#408](https://github.com/avenga/couper/issues/408))
   * missing read of client-request bodies if related variables are used in referenced access controls only (e.g. JWT token source) ([#415](https://github.com/avenga/couper/pull/415))
+  * missing upstream log field value for `request.proto` ([#421](https://github.com/avenga/couper/pull/421))
 
 * **Dependencies**
   * Update [kin-openapi](https://github.com/getkin/kin-openapi) used for [OpenAPI](./docs/REFERENCE.md#openapi-block) validation to `v0.83.0` ([#399](https://github.com/avenga/couper/pull/399))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@
 
 Unreleased changes are available as `avenga/couper:edge` container.
 
+* **Fixed**
+  * missing upstream log field value for `request.proto` ([#421](https://github.com/avenga/couper/pull/421))
+
 ---
 
-## [1.7](https://github.com/avenga/couper/releases/tag/1.7)
+## [1.7](https://github.com/avenga/couper/releases/tag/v1.7.0)
 
 We start 2022 with fresh release of Couper with some exciting features.
 
@@ -44,7 +47,6 @@ On top of that the binary installation has been improved for [homebrew](https://
   * panic while accessing primitive variables with a key ([#377](https://github.com/avenga/couper/issues/377))
   * [`default()`](./docs/REFERENCE.md#functions) function continues to the next fallback value if this is a string type and an argument evaluates to an empty string ([#408](https://github.com/avenga/couper/issues/408))
   * missing read of client-request bodies if related variables are used in referenced access controls only (e.g. JWT token source) ([#415](https://github.com/avenga/couper/pull/415))
-  * missing upstream log field value for `request.proto` ([#421](https://github.com/avenga/couper/pull/421))
 
 * **Dependencies**
   * Update [kin-openapi](https://github.com/getkin/kin-openapi) used for [OpenAPI](./docs/REFERENCE.md#openapi-block) validation to `v0.83.0` ([#399](https://github.com/avenga/couper/pull/399))

--- a/logging/upstream_log.go
+++ b/logging/upstream_log.go
@@ -87,9 +87,7 @@ func (u *UpstreamLog) RoundTrip(req *http.Request) (*http.Response, error) {
 		}
 	}
 
-	if outreq.URL != nil {
-		requestFields["proto"] = outreq.URL.Scheme
-	}
+	requestFields["proto"] = outreq.URL.Scheme
 
 	path := &url.URL{
 		Path:       outreq.URL.Path,

--- a/logging/upstream_log.go
+++ b/logging/upstream_log.go
@@ -57,7 +57,6 @@ func (u *UpstreamLog) RoundTrip(req *http.Request) (*http.Response, error) {
 	requestFields := Fields{
 		"name":   req.Context().Value(request.RoundTripName),
 		"method": req.Method,
-		"proto":  req.URL.Scheme,
 	}
 
 	if req.ContentLength > 0 {
@@ -86,6 +85,10 @@ func (u *UpstreamLog) RoundTrip(req *http.Request) (*http.Response, error) {
 		if requestFields["port"] == "" {
 			delete(requestFields, "port")
 		}
+	}
+
+	if outreq.URL != nil {
+		requestFields["proto"] = outreq.URL.Scheme
 	}
 
 	path := &url.URL{

--- a/server/testdata/integration/api/15_couper.hcl
+++ b/server/testdata/integration/api/15_couper.hcl
@@ -1,0 +1,14 @@
+server {
+  endpoint "/**" {
+
+    request "sidekick" {
+      url = "${env.COUPER_TEST_BACKEND_ADDR}"
+    }
+
+    request {
+      backend {
+        origin = "${env.COUPER_TEST_BACKEND_ADDR}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
use final outreq for url proto log

---
<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>
