### PR TITLE
Fix jwt error kinds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Unreleased changes are available as `avenga/couper:edge` container.
 * **Fixed**
   * improved protection against sniffing using unauthorized requests with non-standard method to non-existant endpoints in protected API ([#441](https://github.com/avenga/couper/pull/441))
   * Couper handles OS-Signal `INT` in all cases in combination with the `-watch` argument ([#456](https://github.com/avenga/couper/pull/456))
+  * some [error types](./docs/ERRORS.md#access-control-error-types) related to [JWT](./docs/REFERENCE.md#jwt-block) ([#438](https://github.com/avenga/couper/pull/438))
 
 ---
 

--- a/accesscontrol/jwt.go
+++ b/accesscontrol/jwt.go
@@ -199,7 +199,7 @@ func (j *JWT) Validate(req *http.Request) error {
 		if strings.ToLower(j.source.Name) == "authorization" {
 			if tokenValue = req.Header.Get(j.source.Name); tokenValue != "" {
 				if tokenValue, err = getBearer(tokenValue); err != nil {
-					return err
+					return errors.JwtTokenMissing.With(err)
 				}
 			}
 		} else {
@@ -498,7 +498,7 @@ func getBearer(val string) (string, error) {
 	if strings.HasPrefix(strings.ToLower(val), bearer) {
 		return strings.Trim(val[len(bearer):], " "), nil
 	}
-	return "", errors.JwtTokenExpired.Message("bearer required with authorization header")
+	return "", fmt.Errorf("bearer required with authorization header")
 }
 
 func newParser(algos []acjwt.Algorithm, claims map[string]interface{}) (*jwt.Parser, error) {

--- a/accesscontrol/jwt.go
+++ b/accesscontrol/jwt.go
@@ -253,7 +253,7 @@ func (j *JWT) Validate(req *http.Request) error {
 
 	tokenClaims, err := j.validateClaims(token, claims)
 	if err != nil {
-		return err
+		return errors.JwtTokenInvalid.With(err)
 	}
 
 	acMap, ok := ctx.Value(request.AccessControls).(map[string]interface{})
@@ -322,12 +322,12 @@ func (j *JWT) validateClaims(token *jwt.Token, claims map[string]interface{}) (m
 	}
 
 	if tokenClaims == nil {
-		return nil, errors.JwtTokenInvalid.Message("token has no claims")
+		return nil, fmt.Errorf("token has no claims")
 	}
 
 	for _, key := range j.claimsRequired {
 		if _, ok := tokenClaims[key]; !ok {
-			return nil, errors.JwtTokenInvalid.Message("required claim is missing: " + key)
+			return nil, fmt.Errorf("required claim is missing: " + key)
 		}
 	}
 
@@ -338,11 +338,11 @@ func (j *JWT) validateClaims(token *jwt.Token, claims map[string]interface{}) (m
 
 		val, exist := tokenClaims[k]
 		if !exist {
-			return nil, errors.JwtTokenInvalid.Message("required claim is missing: " + k)
+			return nil, fmt.Errorf("required claim is missing: " + k)
 		}
 
 		if val != v {
-			return nil, errors.JwtTokenInvalid.Messagef("unexpected value for claim %s: %q, expected %q", k, val, v)
+			return nil, fmt.Errorf("unexpected value for claim %s: %q, expected %q", k, val, v)
 		}
 	}
 	return tokenClaims, nil

--- a/accesscontrol/jwt.go
+++ b/accesscontrol/jwt.go
@@ -245,10 +245,10 @@ func (j *JWT) Validate(req *http.Request) error {
 			return errors.JwtTokenExpired.With(err)
 		case *jwt.UnverfiableTokenError:
 			if unwrappedError := err.ErrorWrapper.Unwrap(); unwrappedError != nil {
-				return unwrappedError
+				return errors.JwtTokenInvalid.With(unwrappedError)
 			}
 		}
-		return err
+		return errors.JwtTokenInvalid.With(err)
 	}
 
 	tokenClaims, err := j.validateClaims(token, claims)

--- a/accesscontrol/jwt_test.go
+++ b/accesscontrol/jwt_test.go
@@ -405,7 +405,7 @@ func Test_JWT_yields_scopes(t *testing.T) {
 			true,
 			"",
 			nil,
-			"invalid scope claim value type, ignoring claim, value: true",
+			"invalid scope claim value type, ignoring claim, value true",
 			noScope,
 		},
 		{
@@ -414,7 +414,7 @@ func Test_JWT_yields_scopes(t *testing.T) {
 			1.23,
 			"",
 			nil,
-			"invalid scope claim value type, ignoring claim, value: 1.23",
+			"invalid scope claim value type, ignoring claim, value 1.23",
 			noScope,
 		},
 		{
@@ -423,7 +423,7 @@ func Test_JWT_yields_scopes(t *testing.T) {
 			[]bool{true, false},
 			"",
 			nil,
-			"invalid scope claim value type, ignoring claim, value: []interface {}{true, false}",
+			"invalid scope claim value type, ignoring claim, value []interface {}{true, false}",
 			noScope,
 		},
 		{
@@ -432,7 +432,7 @@ func Test_JWT_yields_scopes(t *testing.T) {
 			[]int{1, 2},
 			"",
 			nil,
-			"invalid scope claim value type, ignoring claim, value: []interface {}{1, 2}",
+			"invalid scope claim value type, ignoring claim, value []interface {}{1, 2}",
 			noScope,
 		},
 		{
@@ -441,7 +441,7 @@ func Test_JWT_yields_scopes(t *testing.T) {
 			[]interface{}{"eins", 2},
 			"",
 			nil,
-			`invalid scope claim value type, ignoring claim, value: []interface {}{"eins", 2}`,
+			`invalid scope claim value type, ignoring claim, value []interface {}{"eins", 2}`,
 			noScope,
 		},
 		{
@@ -450,7 +450,7 @@ func Test_JWT_yields_scopes(t *testing.T) {
 			map[string]interface{}{"foo": 1, "bar": 1},
 			"",
 			nil,
-			`invalid scope claim value type, ignoring claim, value: map[string]interface {}{"bar":1, "foo":1}`,
+			`invalid scope claim value type, ignoring claim, value map[string]interface {}{"bar":1, "foo":1}`,
 			noScope,
 		},
 		{
@@ -522,7 +522,7 @@ func Test_JWT_yields_scopes(t *testing.T) {
 			nil,
 			"roles",
 			true,
-			"invalid roles claim value type, ignoring claim, value: true",
+			"invalid roles claim value type, ignoring claim, value true",
 			[]string{"default"},
 		},
 		{
@@ -531,7 +531,7 @@ func Test_JWT_yields_scopes(t *testing.T) {
 			nil,
 			"roles",
 			1.23,
-			"invalid roles claim value type, ignoring claim, value: 1.23",
+			"invalid roles claim value type, ignoring claim, value 1.23",
 			[]string{"default"},
 		},
 		{
@@ -540,7 +540,7 @@ func Test_JWT_yields_scopes(t *testing.T) {
 			nil,
 			"roles",
 			[]bool{true, false},
-			"invalid roles claim value type, ignoring claim, value: []interface {}{true, false}",
+			"invalid roles claim value type, ignoring claim, value []interface {}{true, false}",
 			[]string{"default"},
 		},
 		{
@@ -549,7 +549,7 @@ func Test_JWT_yields_scopes(t *testing.T) {
 			nil,
 			"roles",
 			[]int{1, 2},
-			"invalid roles claim value type, ignoring claim, value: []interface {}{1, 2}",
+			"invalid roles claim value type, ignoring claim, value []interface {}{1, 2}",
 			[]string{"default"},
 		},
 		{
@@ -558,7 +558,7 @@ func Test_JWT_yields_scopes(t *testing.T) {
 			nil,
 			"roles",
 			[]interface{}{"user1", 2},
-			`invalid roles claim value type, ignoring claim, value: []interface {}{"user1", 2}`,
+			`invalid roles claim value type, ignoring claim, value []interface {}{"user1", 2}`,
 			[]string{"default"},
 		},
 		{
@@ -567,7 +567,7 @@ func Test_JWT_yields_scopes(t *testing.T) {
 			nil,
 			"roles",
 			map[string]interface{}{"foo": 1, "bar": 1},
-			`invalid roles claim value type, ignoring claim, value: map[string]interface {}{"bar":1, "foo":1}`,
+			`invalid roles claim value type, ignoring claim, value map[string]interface {}{"bar":1, "foo":1}`,
 			[]string{"default"},
 		},
 		{

--- a/accesscontrol/jwt_test.go
+++ b/accesscontrol/jwt_test.go
@@ -186,11 +186,21 @@ func Test_JWT_Validate(t *testing.T) {
 			req         *http.Request
 			wantErrKind string
 		}{
-			{"src: header /w empty bearer", fields{
+			{"src: header /w no authorization header", fields{
 				algorithm: algo,
 				source:    ac.NewJWTSource("", "Authorization", nil),
 				pubKey:    pubKeyBytes,
 			}, httptest.NewRequest(http.MethodGet, "/", nil), "jwt_token_missing"},
+			{"src: header /w different auth-scheme", fields{
+				algorithm: algo,
+				source:    ac.NewJWTSource("", "Authorization", nil),
+				pubKey:    pubKeyBytes,
+			}, setCookieAndHeader(httptest.NewRequest(http.MethodGet, "/", nil), "Authorization", "Basic qbqnb"), "jwt_token_missing"},
+			{"src: header /w empty bearer", fields{
+				algorithm: algo,
+				source:    ac.NewJWTSource("", "Authorization", nil),
+				pubKey:    pubKeyBytes,
+			}, setCookieAndHeader(httptest.NewRequest(http.MethodGet, "/", nil), "Authorization", "BeAreR"), "jwt_token_missing"},
 			{"src: header /w valid bearer", fields{
 				algorithm: algo,
 				source:    ac.NewJWTSource("", "Authorization", nil),

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -64,16 +64,16 @@ All errors have a specific type. You can find it in the log field `error_type`. 
 
 ### Access control error types
 
-| Type (and super types)                          | Description                                                                                      | Default handling                                                            |
-|:------------------------------------------------|:-------------------------------------------------------------------------------------------------|:----------------------------------------------------------------------------|
-| `basic_auth`                                    | All `basic_auth` related errors, e.g. unknown user or wrong password.                            | Send error template with status `401` and `WWW-Authenticate: Basic` header. |
-| `basic_auth_credentials_missing` (`basic_auth`) | Client does not provide any credentials.                                                         | Send error template with status `401` and `WWW-Authenticate: Basic` header. |
-| `jwt`                                           | All `jwt` related errors.                                                                        | Send error template with status `403`.                                      |
-| `jwt_token_missing` (`jwt`)                     | No token provided with configured token source.                                                  | Send error template with status `401`.                                      |
-| `jwt_token_expired` (`jwt`)                     | Given token is valid but expired.                                                                | Send error template with status `403`.                                      |
-| `jwt_token_invalid` (`jwt`)                     | The token is not sufficient, e.g. because required claims are missing or have unexpected values. | Send error template with status `403`.                                      |
-| `saml` (or `saml2`)                             | All `saml` related errors                                                                        | Send error template with status `403`.                                      |
-| `oauth2`                                        | All `beta_oauth2`/`oidc` related errors                                                          | Send error template with status `403`.                                      |
+| Type (and super types)                          | Description                                                                                                                  | Default handling                                                            |
+|:------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------|:----------------------------------------------------------------------------|
+| `basic_auth`                                    | All `basic_auth` related errors, e.g. unknown user or wrong password.                                                        | Send error template with status `401` and `WWW-Authenticate: Basic` header. |
+| `basic_auth_credentials_missing` (`basic_auth`) | Client does not provide any credentials.                                                                                     | Send error template with status `401` and `WWW-Authenticate: Basic` header. |
+| `jwt`                                           | All `jwt` related errors.                                                                                                    | Send error template with status `403`.                                      |
+| `jwt_token_missing` (`jwt`)                     | No token provided with configured token source.                                                                              | Send error template with status `401`.                                      |
+| `jwt_token_expired` (`jwt`)                     | Given token is valid but expired.                                                                                            | Send error template with status `403`.                                      |
+| `jwt_token_invalid` (`jwt`)                     | The token is syntactically not a JWT, or not sufficient, e.g. because required claims are missing or have unexpected values. | Send error template with status `403`.                                      |
+| `saml` (or `saml2`)                             | All `saml` related errors                                                                                                    | Send error template with status `403`.                                      |
+| `oauth2`                                        | All `beta_oauth2`/`oidc` related errors                                                                                      | Send error template with status `403`.                                      |
 
 ### API and endpoint error types
 

--- a/server/http_endpoints_test.go
+++ b/server/http_endpoints_test.go
@@ -916,13 +916,13 @@ func TestEndpointACBufferOptions(t *testing.T) {
 	}
 
 	for _, tc := range []testcase{
-		{"with ac (token in-form_body) and wrong token", "/in-form_body", invalidToken, urlencoded, "application/x-www-form-urlencoded", http.StatusForbidden, "jwt"},
+		{"with ac (token in-form_body) and wrong token", "/in-form_body", invalidToken, urlencoded, "application/x-www-form-urlencoded", http.StatusForbidden, "jwt_token_invalid"},
 		{"with ac (token in-form_body) and without token", "/in-form_body", "", urlencoded, "application/x-www-form-urlencoded", http.StatusUnauthorized, "jwt_token_missing"},
 		{"with ac (token in-form_body) and valid token", "/in-form_body", validToken, urlencoded, "application/x-www-form-urlencoded", http.StatusOK, ""},
-		{"with ac (token in-json_body) and wrong token", "/in-json_body", invalidToken, jsonFn, "application/json", http.StatusForbidden, "jwt"},
+		{"with ac (token in-json_body) and wrong token", "/in-json_body", invalidToken, jsonFn, "application/json", http.StatusForbidden, "jwt_token_invalid"},
 		{"with ac (token in-json_body) and without token", "/in-json_body", "", jsonFn, "application/json", http.StatusUnauthorized, "jwt_token_missing"},
 		{"with ac (token in-json_body) and valid token", "/in-json_body", validToken, jsonFn, "application/json", http.StatusOK, ""},
-		{"with ac (token in-body) and wrong token", "/in-body", invalidToken, plain, "text/plain", http.StatusForbidden, "jwt"},
+		{"with ac (token in-body) and wrong token", "/in-body", invalidToken, plain, "text/plain", http.StatusForbidden, "jwt_token_invalid"},
 		{"with ac (token in-body) and without token", "/in-body", "", plain, "text/plain", http.StatusUnauthorized, "jwt_token_missing"},
 		{"with ac (token in-body) and valid token", "/in-body", validToken, plain, "text/plain", http.StatusOK, ""},
 		{"without ac", "/without-ac", "", nil, "text/plain", http.StatusOK, ""},


### PR DESCRIPTION
All invalid tokens cause error with "jwt_token_invalid".
Missing tokens in `Authorization: Bearer` cause error with "jwt_token_missing".

---
<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>
