### PR TITLE
Fix missing os signal handling with watch option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Unreleased changes are available as `avenga/couper:edge` container.
 
 * **Fixed**
   * improved protection against sniffing using unauthorized requests with non-standard method to non-existant endpoints in protected API ([#441](https://github.com/avenga/couper/pull/441))
+  * Couper handles OS-Signal `INT` in all cases in combination with the `-watch` argument ([#456](https://github.com/avenga/couper/pull/456))
 
 ---
 

--- a/main.go
+++ b/main.go
@@ -154,6 +154,9 @@ func realmain(arguments []string) int {
 		debugListenAndServe(logger)
 	}
 
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
 	reloadCh := watchConfigFile(confFile.Filename, logger, flags.FileWatchRetries, flags.FileWatchRetryDelay)
 	for {
 		select {
@@ -180,6 +183,9 @@ func realmain(arguments []string) int {
 				logger.WithError(err).Error()
 				return 1
 			}
+			return 0
+		case <-sigCh:
+			close(restartSignal)
 			return 0
 		case _, more := <-reloadCh:
 			if !more {


### PR DESCRIPTION
No proper server shutdown while running Couper with the `-watch` option.

---
<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>
