### PR TITLE
Error handler api endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Unreleased changes are available as `avenga/couper:edge` container.
 * **Fixed**
   * Keys in object type attribute values are only handled case-insensitively if reasonable (e.g. they represent HTTP methods or header field values) ([#461](https://github.com/avenga/couper/pull/461))
   * Multiple labels for [`error_handler` blocks](./docs/ERRORS.md#error_handler-specification) ([#462](https://github.com/avenga/couper/pull/462))
+  * [`error_handler` blocks](./docs/REFERENCE.md#error-handler-block) for an error type defined in both `endpoint` and `api` ([#469](https://github.com/avenga/couper/pull/469))
 
 ---
 

--- a/config/runtime/error_handler.go
+++ b/config/runtime/error_handler.go
@@ -13,8 +13,8 @@ import (
 )
 
 var wildcardMap = map[string][]string{
-	"api":      []string{"beta_insufficient_scope", "beta_operation_denied"},
-	"endpoint": []string{"beta_insufficient_scope", "beta_operation_denied", "sequence", "unexpected_status"},
+	"api":      {"beta_insufficient_scope", "beta_operation_denied"},
+	"endpoint": {"beta_insufficient_scope", "beta_operation_denied", "sequence", "unexpected_status"},
 }
 
 func newErrorHandler(ctx *hcl.EvalContext, opts *protectedOptions, log *logrus.Entry,

--- a/config/runtime/error_handler.go
+++ b/config/runtime/error_handler.go
@@ -49,41 +49,41 @@ func newErrorHandler(ctx *hcl.EvalContext, opts *protectedOptions, log *logrus.E
 		}
 
 		for k, h := range handlersPerKind {
-				contextBody := h.HCLBody()
+			contextBody := h.HCLBody()
 
-				epConf := &config.Endpoint{
-					Remain:    contextBody,
-					Proxies:   h.Proxies,
-					ErrorFile: h.ErrorFile,
-					Requests:  h.Requests,
-					Response:  h.Response,
-				}
+			epConf := &config.Endpoint{
+				Remain:    contextBody,
+				Proxies:   h.Proxies,
+				ErrorFile: h.ErrorFile,
+				Requests:  h.Requests,
+				Response:  h.Response,
+			}
 
-				emptyBody := hcl.EmptyBody()
-				if epConf.Response == nil { // Set dummy resp to skip related requirement checks, allowed for error_handler.
-					epConf.Response = &config.Response{Remain: emptyBody}
-				}
+			emptyBody := hcl.EmptyBody()
+			if epConf.Response == nil { // Set dummy resp to skip related requirement checks, allowed for error_handler.
+				epConf.Response = &config.Response{Remain: emptyBody}
+			}
 
-				epOpts, err := newEndpointOptions(ctx, epConf, nil, opts.srvOpts, log, opts.settings, opts.memStore)
-				if err != nil {
-					return nil, err
-				}
-				if epOpts.ErrorTemplate == nil || h.ErrorFile == "" {
-					epOpts.ErrorTemplate = opts.epOpts.ErrorTemplate
-				}
+			epOpts, err := newEndpointOptions(ctx, epConf, nil, opts.srvOpts, log, opts.settings, opts.memStore)
+			if err != nil {
+				return nil, err
+			}
+			if epOpts.ErrorTemplate == nil || h.ErrorFile == "" {
+				epOpts.ErrorTemplate = opts.epOpts.ErrorTemplate
+			}
 
-				epOpts.ErrorTemplate = epOpts.ErrorTemplate.WithContextFunc(func(rw http.ResponseWriter, r *http.Request) {
-					beresp := &http.Response{Header: rw.Header()}
-					_ = eval.ApplyResponseContext(eval.ContextFromRequest(r).HCLContextSync(), contextBody, beresp)
-				})
+			epOpts.ErrorTemplate = epOpts.ErrorTemplate.WithContextFunc(func(rw http.ResponseWriter, r *http.Request) {
+				beresp := &http.Response{Header: rw.Header()}
+				_ = eval.ApplyResponseContext(eval.ContextFromRequest(r).HCLContextSync(), contextBody, beresp)
+			})
 
-				if epOpts.Response != nil && reflect.DeepEqual(epOpts.Response.Context, emptyBody) {
-					epOpts.Response = nil
-				}
+			if epOpts.Response != nil && reflect.DeepEqual(epOpts.Response.Context, emptyBody) {
+				epOpts.Response = nil
+			}
 
-				epOpts.LogHandlerKind = "error_" + k
-				epOpts.IsErrorHandler = true
-				kindsHandler[k] = handler.NewEndpoint(epOpts, log, nil)
+			epOpts.LogHandlerKind = "error_" + k
+			epOpts.IsErrorHandler = true
+			kindsHandler[k] = handler.NewEndpoint(epOpts, log, nil)
 		}
 	}
 

--- a/config/runtime/error_handler.go
+++ b/config/runtime/error_handler.go
@@ -1,7 +1,6 @@
 package runtime
 
 import (
-	"fmt"
 	"net/http"
 	"reflect"
 
@@ -13,6 +12,11 @@ import (
 	"github.com/avenga/couper/handler"
 )
 
+var wildcardMap = map[string][]string{
+	"api":      []string{"beta_insufficient_scope", "beta_operation_denied"},
+	"endpoint": []string{"beta_insufficient_scope", "beta_operation_denied", "sequence", "unexpected_status"},
+}
+
 func newErrorHandler(ctx *hcl.EvalContext, opts *protectedOptions, log *logrus.Entry,
 	defs ACDefinitions, references ...string) (http.Handler, error) {
 	kindsHandler := map[string]http.Handler{}
@@ -21,12 +25,30 @@ func newErrorHandler(ctx *hcl.EvalContext, opts *protectedOptions, log *logrus.E
 		if !ok {
 			continue
 		}
+
+		handlersPerKind := make(map[string]*config.ErrorHandler)
 		for _, h := range definition.ErrorHandler {
 			for _, k := range h.Kinds {
-				if _, exist := kindsHandler[k]; exist {
-					return nil, fmt.Errorf("error handler type already exists: " + k)
-				}
+				handlersPerKind[k] = h
+			}
+		}
 
+		// this works if wildcard is the only "super kind"
+		if mappedKinds, mkExists := wildcardMap[ref]; mkExists {
+			// expand wildcard:
+			// * set wildcard error handler for mapped kinds, no error handler for this kind is already set
+			// * remove wildcard error handler for wildcard
+			if wcHandler, wcExists := handlersPerKind["*"]; wcExists {
+				for _, mk := range mappedKinds {
+					if _, exists := handlersPerKind[mk]; !exists {
+						handlersPerKind[mk] = wcHandler
+					}
+				}
+			}
+			delete(handlersPerKind, "*")
+		}
+
+		for k, h := range handlersPerKind {
 				contextBody := h.HCLBody()
 
 				epConf := &config.Endpoint{
@@ -62,7 +84,6 @@ func newErrorHandler(ctx *hcl.EvalContext, opts *protectedOptions, log *logrus.E
 				epOpts.LogHandlerKind = "error_" + k
 				epOpts.IsErrorHandler = true
 				kindsHandler[k] = handler.NewEndpoint(epOpts, log, nil)
-			}
 		}
 	}
 

--- a/config/runtime/server.go
+++ b/config/runtime/server.go
@@ -310,7 +310,7 @@ func NewServerConfiguration(conf *config.Couper, log *logrus.Entry, memStore *ca
 					memStore: memStore,
 					settings: conf.Settings,
 					srvOpts:  serverOptions,
-				}, log, errorHandlerDefinitions, "api", "endpoint")
+				}, log, errorHandlerDefinitions, "api", "endpoint") // sequence of ref is important: api, endpoint (endpoint error_handler overrides api error_handler)
 				if err != nil {
 					return nil, err
 				}
@@ -330,7 +330,7 @@ func NewServerConfiguration(conf *config.Couper, log *logrus.Entry, memStore *ca
 					memStore: memStore,
 					settings: conf.Settings,
 					srvOpts:  serverOptions,
-				}, log, errorHandlerDefinitions, "api", "endpoint")
+				}, log, errorHandlerDefinitions, "api", "endpoint") // sequence of ref is important: api, endpoint (endpoint error_handler overrides api error_handler)
 				if err != nil {
 					return nil, err
 				}

--- a/server/http_error_handler_test.go
+++ b/server/http_error_handler_test.go
@@ -148,6 +148,8 @@ func TestAccessControl_ErrorHandler_Scopes(t *testing.T) {
 		{"api pow: w/ scope method; handle operation_denied", http.MethodGet, "/api/pow/", []string{"read", "another"}, http.StatusMethodNotAllowed, ""},
 		{"endpoint: w/ scope", http.MethodGet, "/", []string{"write"}, http.StatusOK, ""},
 		{"endpoint: w/ wrong scope; handle scope", http.MethodGet, "/", []string{"another"}, http.StatusTeapot, ""},
+		{"api specific, endpoint *: w/ wrong scope; handle scope", http.MethodGet, "/wildcard1/", []string{"another"}, http.StatusBadRequest, ""},
+		{"api *, endpoint specific: w/ wrong scope; handle scope", http.MethodGet, "/wildcard2/", []string{"another"}, http.StatusBadRequest, ""},
 	} {
 		t.Run(tc.Name, func(st *testing.T) {
 			h := test.New(st)

--- a/server/testdata/integration/error_handler/04_couper.hcl
+++ b/server/testdata/integration/error_handler/04_couper.hcl
@@ -44,6 +44,58 @@ server "scoped" {
 
   }
 
+  api {
+    base_path = "/wildcard1"
+
+    error_handler "beta_insufficient_scope" {
+      response {
+        status = 418
+        body = "Not enough power"
+      }
+    }
+
+    endpoint "/" {
+      beta_scope = "power"
+
+      response {
+        status = 204
+      }
+
+      error_handler "*" {
+        response {
+          status = 400
+          body = "Not enough power"
+        }
+      }
+    }
+  }
+
+  api {
+    base_path = "/wildcard2"
+
+    error_handler {
+      response {
+        status = 418
+        body = "Not enough power"
+      }
+    }
+
+    endpoint "/" {
+      beta_scope = "power"
+
+      response {
+        status = 204
+      }
+
+      error_handler "beta_insufficient_scope" {
+        response {
+          status = 400
+          body = "Not enough power"
+        }
+      }
+    }
+  }
+
   endpoint "/" {
     beta_scope = "write"
 

--- a/server/testdata/integration/error_handler/04_couper.hcl
+++ b/server/testdata/integration/error_handler/04_couper.hcl
@@ -36,7 +36,7 @@ server "scoped" {
       }
     }
 
-    error_handler "beta_scope" {
+    error_handler "beta_insufficient_scope" {
       response {
         status = 418
       }


### PR DESCRIPTION
Enabled `error_handler`s for an error type defined in both `endpoint` and `api` with expanding `*` wildcard error type.

---
<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>
