### PR TITLE
Multi-File-Config refinements

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -37,12 +37,15 @@ the path of `-d <dir>` is the working directory of Couper. A `couper.hcl` file i
 `-f <file>`. Other files in the `-d <dir>` are loaded in alphabetical order. Example:
 
 ```sh
-|- couper.hcl    # defined via `-f`                       <|
-|- couper.d/     # defined via `-d`                        |
-|  |- couper.hcl # patches the couper.hcl              <|  |
-|  |- a.hcl      # patches the couper.d/couper.hcl  <|  |
-|  |- z.hcl      # patches the couper.d/a.hcl        |
+|- couper.hcl    # defined via `-f`
+|- couper.d/     # defined via `-d`
+|  |- couper.hcl # step 3: merge configuration into the couper.hcl defined via `-f`
+|  |- a.hcl      # step 2: merge configuration into the couper.d/couper.hcl
+|  |- z.hcl      # step 1: merge configuration into the couper.d/a.hcl
 ```
+
+_Note_: When merging configuration files, only one unlabeled `server` or `api` block
+is allowed in each context.
 
 ## Run Options
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -9,7 +9,7 @@ Couper is build as binary called `couper` with the following commands:
 | Command   | Description                                                                                                                                   |
 |:----------|:----------------------------------------------------------------------------------------------------------------------------------------------|
 | `run`     | Start the server with given configuration file.                                                                                               |
-|           | _Note_: `run` options can also be configured with [settings](REFERENCE.md#settings-block) or related [environment variables](./../DOCKER.md). |
+|           | **Note:** `run` options can also be configured with [settings](REFERENCE.md#settings-block) or related [environment variables](./../DOCKER.md). |
 | `help`    | Print the usage for the given command: `help run`                                                                                             |
 | `verify`  | Verify the syntax of the given configuration file.                                                                                            |
 | `version` | Print the current version and build information.                                                                                              |
@@ -28,9 +28,9 @@ Couper is build as binary called `couper` with the following commands:
 | `-log-pretty`        | `false`      | `COUPER_LOG_PRETTY`        | Option for `json` log format which pretty prints with basic key coloring.                                                    |
 | `-ca-file`           | `""`         | `COUPER_CA_FILE`           | Option for adding the given PEM encoded ca-certificate to the existing system certificate pool for all outgoing connections. |
 
-_Note_: `log-format`, `log-level` and `log-pretty` also map to [settings](REFERENCE.md#settings-block).
+**Note:** `log-format`, `log-level` and `log-pretty` also map to [settings](REFERENCE.md#settings-block).
 
-_Note_: Couper can be started with both, `-f` and `-d` arguments. The path of `-f <file>`
+**Note:** Couper can be started with both, `-f` and `-d` arguments. The path of `-f <file>`
 determines the working directory of Couper. If `-d <dir>` argument is given without the `-f <file>`,
 the path of `-d <dir>` is the working directory of Couper. A `couper.hcl` file inside the
 `-d <dir>` is priorized over other files inside the `-d <dir>`, but not over the
@@ -44,7 +44,7 @@ the path of `-d <dir>` is the working directory of Couper. A `couper.hcl` file i
 |  |- z.hcl      # step 1: merge configuration into the couper.d/a.hcl
 ```
 
-_Note_: When merging configuration files, only one unlabeled `server` or `api` block
+**Note:** When merging configuration files, only one unlabeled `server` or `api` block
 is allowed in each context.
 
 ## Run Options

--- a/docs/MERGE.md
+++ b/docs/MERGE.md
@@ -1,0 +1,77 @@
+# Merging
+
+Couper supports merging of blocks and attributes from multiple configuration files
+(see [Global Options of Command Line Interface](CLI.md#global-options)).
+
+* [General Rules of Merging](#general-rules-of-merging)
+* [Merging of `server` Blocks](#merging-of-server-blocks)
+* [Merging of `definitions` Blocks](#merging-of-definitions-blocks)
+* [Merging of `defaults` Blocks](#merging-of-defaults-blocks)
+* [Merging of `settings` Blocks](#merging-of-settings-blocks)
+
+## General Rules of Merging
+
+When merging, all attributes (except `environment_variables` in the `defaults` block)
+replace existing attributes with the same name, if any, otherwise they are added.
+
+Blocks that cannot have labels (eg. `cors`, `files` etc.) replace existing blocks
+with the same name, if any, otherwise they are added.
+
+Blocks with optional labels (eg. `server`, `api` etc.) are merged recursively with
+blocks with the same label (blocks without a label are merged with blocks with the
+same name and no label in each context), if any, otherwise they are added. Only one
+unlabeled block of the same type is allowed in each context (eg. `api` blocks in
+a `server` block).
+
+Blocks with required label (eg. `endpoint`) replace existing blocks with the same
+name and label in each context, if any, otherwise they are added.
+
+Blocks with (optional) multiple labels (eg. `error_handler`) replace existing blocks
+with identical labels, if any, otherwise they are added.
+
+Currently here is no way to remove an attribute or a block from the configuration.
+
+## Merging of `server` Blocks
+
+* When `server` blocks are merged:
+  * All attributes replace existing attributes with the same name, if any, otherwise
+    they are added.
+  * The `cors`, `files` and `spa` blocks replace existing blocks with the same 
+    name, if any, otherwise they are added.
+  * All `endpoint` blocks replace existing blocks with the same label, if any, otherwise
+    they are added.
+  * When `api` blocks are merged:
+    * All attributes replace existing attributes with the same name, if any, otherwise
+	  they are added.
+    * The `cors` block replaces existing `cors` block, if any, otherwise a new `cors`
+	  block is added.
+    * All `endpoint` blocks replace existing blocks with the same label, if any,
+	  otherwise they are added.
+    * All `error_handler` blocks replace existing blocks with identical labels,
+	  if any, otherwise they are added.
+
+**Note:** An `error_handler` block cannot be replaced in or added to an `endpoint`
+block. Therefore, the `endpoint` block must be completely replaced.
+
+## Merging of `definitions` Blocks
+
+* The `definitions` blocks are merged recursively, if any, otherwise a new `definitions`
+  block is added.
+  * All blocks inside a `definitions` block replace existing blocks with the same
+    name and label.
+
+## Merging of `defaults` Blocks
+
+* The `defaults` blocks are merged recursively, if any, otherwise a new `defaults`
+  block is added.
+  * All attributes inside a `defaults` block (except `environment_variables`) replace
+    existing attributes with the same name, if any, otherwise they are added.
+  * Single values of an `environment_variables` attribute replace existing values
+    with the same key, if any, otherwise they are added.
+
+## Merging of `settings` Blocks
+
+* The `settings` blocks are merged recursively, if any, otherwise a new `settings`
+  block is added.
+  * All attributes inside a `settings` block replace existing attributes with the
+    same name, if any, otherwise they are added.

--- a/docs/MERGE.md
+++ b/docs/MERGE.md
@@ -3,11 +3,12 @@
 Couper supports merging of blocks and attributes from multiple configuration files
 (see [Global Options of Command Line Interface](CLI.md#global-options)).
 
-* [General Rules of Merging](#general-rules-of-merging)
-* [Merging of `server` Blocks](#merging-of-server-blocks)
-* [Merging of `definitions` Blocks](#merging-of-definitions-blocks)
-* [Merging of `defaults` Blocks](#merging-of-defaults-blocks)
-* [Merging of `settings` Blocks](#merging-of-settings-blocks)
+* [Merging](#merging)
+  * [General Rules of Merging](#general-rules-of-merging)
+  * [Merging of `server` Blocks](#merging-of-server-blocks)
+  * [Merging of `definitions` Blocks](#merging-of-definitions-blocks)
+  * [Merging of `defaults` Blocks](#merging-of-defaults-blocks)
+  * [Merging of `settings` Blocks](#merging-of-settings-blocks)
 
 ## General Rules of Merging
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -48,6 +48,7 @@
     - [Query Parameter](#query-parameter)
     - [Form Parameter](#form-parameter)
     - [Path Parameter](#path-parameter)
+  - [Merging from multiple configuration files](MERGE.md)
 
 ## Block Reference
 
@@ -406,7 +407,7 @@ A JWT access control configured by this block can extract scope values from
 
 The `jwt` block may also be referenced by the [`jwt_sign()` function](#functions), if it has a `signing_ttl` defined. For `HS*` algorithms the signing key is taken from `key`/`key_file`, for `RS*` and `ES*` algorithms, `signing_key` or `signing_key_file` have to be specified.
 
-*Note:* A `jwt` block with `signing_ttl` cannot have the same label as a `jwt_signing_profile` block.
+**Note:** A `jwt` block with `signing_ttl` cannot have the same label as a `jwt_signing_profile` block.
 
 | Attribute(s) | Type |Default|Description|Characteristic(s)| Example|
 | :-------- | :--------------- | :--------------- | :--------------- | :--------------- | :--------------- |

--- a/server/multi_files_test.go
+++ b/server/multi_files_test.go
@@ -111,6 +111,14 @@ func TestMultiFiles_SettingsAndDefaults(t *testing.T) {
 		t.Errorf("Missing 'Req-Id-Cl-Hdr' header")
 	}
 
+	if res.Header.Get("X") != "X" {
+		t.Errorf("Invalid 'X' header given")
+	}
+
+	if res.Header.Get("Y") != "Y" {
+		t.Errorf("Invalid 'Y' header given")
+	}
+
 	// Call health route
 	req, err = http.NewRequest(http.MethodGet, "http://example.com:8080/xyz", nil)
 	helper.Must(err)

--- a/server/testdata/multi/settings/couper.hcl
+++ b/server/testdata/multi/settings/couper.hcl
@@ -2,6 +2,11 @@ server {
   endpoint "/" {
     proxy {
       url = "${env.COUPER_TEST_BACKEND_ADDR}/anything"
+
+	  set_response_headers = {
+		  X: env.X
+		  Y: env.Y
+	  }
     }
   }
 }


### PR DESCRIPTION
Added docu, `environment_variables` are merged insted of replaced.

---
<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>
