### PR TITLE
Remove the word 'fail' from (sub)test names ...

### DIFF
--- a/config/configload/load_test.go
+++ b/config/configload/load_test.go
@@ -92,7 +92,7 @@ func TestHealthCheck(t *testing.T) {
 			`time: missing unit in duration "1"`,
 		},
 		{
-			"Bad failure_threshold",
+			"Bad threshold",
 			`failure_threshold = -1`,
 			"couper.hcl:13,29-30: Unsuitable value type; Unsuitable value: value must be a whole number, between 0 and 18446744073709551615 inclusive",
 		},

--- a/server/http_integration_test.go
+++ b/server/http_integration_test.go
@@ -2730,7 +2730,7 @@ func TestHTTPServer_BackendProbes(t *testing.T) {
 			`{"error":"unexpected statusCode: 302","healthy":false,"state":"unhealthy"}`,
 		},
 		{
-			"failing backend: timeout but threshold not reached",
+			"backend error: timeout but threshold not reached",
 			"/failing",
 			`{"error":"backend error: proxyconnect tcp: dial tcp 127.0.0.1:9999: connect: connection refused","healthy":true,"state":"failing"}`,
 		},

--- a/server/modifier_test.go
+++ b/server/modifier_test.go
@@ -45,7 +45,7 @@ func TestIntegration_ResponseHeaders(t *testing.T) {
 			},
 		},
 		{
-			path:       "/fail",
+			path:       "/not-found",
 			expHeaders: http.Header{},
 		},
 	} {


### PR DESCRIPTION
... due to golang test status: FAIL

---
<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>
