### PR TITLE
Fix missing `env.` key error

### DIFF
--- a/config/configload/helper.go
+++ b/config/configload/helper.go
@@ -19,7 +19,7 @@ type helper struct {
 }
 
 // newHelper creates a container with some methods to keep things simple here and there.
-func newHelper(body hcl.Body, src []byte, filename string) (*helper, error) {
+func newHelper(body hcl.Body, src [][]byte) (*helper, error) {
 	defaultsBlock := &config.DefaultsBlock{}
 	if diags := gohcl.DecodeBody(body, nil, defaultsBlock); diags.HasErrors() {
 		return nil, diags
@@ -28,10 +28,9 @@ func newHelper(body hcl.Body, src []byte, filename string) (*helper, error) {
 	defSettings := config.DefaultSettings
 
 	couperConfig := &config.Couper{
-		Context:     eval.NewContext([][]byte{src}, defaultsBlock.Defaults),
+		Context:     eval.NewContext(src, defaultsBlock.Defaults),
 		Definitions: &config.Definitions{},
 		Defaults:    defaultsBlock.Defaults,
-		Filename:    filename,
 		Settings:    &defSettings,
 	}
 

--- a/config/configload/load.go
+++ b/config/configload/load.go
@@ -154,7 +154,7 @@ func LoadFiles(filesList []string) (*config.Couper, error) {
 	}
 
 	for _, body := range parsedBodies {
-		if err := absolutizePaths(body); err != nil {
+		if err = absolutizePaths(body); err != nil {
 			return nil, err
 		}
 	}

--- a/config/configload/load.go
+++ b/config/configload/load.go
@@ -74,7 +74,7 @@ func updateContext(body hcl.Body, srcBytes [][]byte) hcl.Diagnostics {
 		return diags
 	}
 
-	// We need the "envContext" to be able to resolve abs pathes in the config.
+	// We need the "envContext" to be able to resolve absolute paths in the config.
 	defaultsConfig = defaultsBlock.Defaults
 	evalContext = eval.NewContext(srcBytes, defaultsConfig)
 	envContext = evalContext.HCLContext()
@@ -180,7 +180,7 @@ func LoadFiles(filesList []string) (*config.Couper, error) {
 		Blocks: configBlocks,
 	}
 
-	conf, err := LoadConfig(configBody, srcBytes[0], filesList[0])
+	conf, err := LoadConfig(configBody, srcBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -200,21 +200,17 @@ func LoadBytes(src []byte, filename string) (*config.Couper, error) {
 		return nil, diags
 	}
 
-	if diags = updateContext(hclBody, [][]byte{src}); diags.HasErrors() {
-		return nil, diags
-	}
-
-	return LoadConfig(hclBody, src, filename)
+	return LoadConfig(hclBody, [][]byte{src})
 }
 
-func LoadConfig(body hcl.Body, src []byte, filename string) (*config.Couper, error) {
+func LoadConfig(body hcl.Body, src [][]byte) (*config.Couper, error) {
 	var err error
 
 	if diags := ValidateConfigSchema(body, &config.Couper{}); diags.HasErrors() {
 		return nil, diags
 	}
 
-	helper, err := newHelper(body, src, filename)
+	helper, err := newHelper(body, src)
 	if err != nil {
 		return nil, err
 	}

--- a/config/couper.go
+++ b/config/couper.go
@@ -11,7 +11,6 @@ const DefaultFilename = "couper.hcl"
 // Couper represents the <Couper> config object.
 type Couper struct {
 	Context     context.Context
-	Filename    string
 	Files       file.Files
 	Definitions *Definitions `hcl:"definitions,block"`
 	Servers     Servers      `hcl:"server,block"`

--- a/main.go
+++ b/main.go
@@ -45,12 +45,11 @@ type filesList struct {
 }
 
 func main() {
-	logrus.Exit(realmain(os.Args))
+	logrus.Exit(realmain(context.Background(), os.Args))
 }
 
-func realmain(arguments []string) int {
+func realmain(ctx context.Context, arguments []string) int {
 	args := command.NewArgs(arguments)
-	ctx := context.Background()
 	filesList := filesList{}
 
 	type globalFlags struct {

--- a/main_test.go
+++ b/main_test.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	logrustest "github.com/sirupsen/logrus/hooks/test"
 
@@ -57,7 +59,10 @@ func Test_realmain(t *testing.T) {
 				})
 			}
 
-			if got := realmain(tt.args); got != tt.want {
+			ctx, cancel := context.WithCancel(context.Background())
+			time.AfterFunc(time.Second, cancel)
+
+			if got := realmain(ctx, tt.args); got != tt.want {
 				subT.Errorf("realmain() = %v, want %v", got, tt.want)
 			}
 			env.OsEnviron = os.Environ

--- a/main_test.go
+++ b/main_test.go
@@ -46,6 +46,7 @@ func Test_realmain(t *testing.T) {
 		{"non-existent log level via env /w file", []string{"couper", "run", "-f", base + "/log_altered.hcl"}, []string{"COUPER_LOG_LEVEL=test"}, `level=error msg="configuration error: missing 'server' block" build=dev`, 1},
 		{"-f w/o file", []string{"couper", "run", "-f"}, nil, `level=error msg="flag needs an argument: -f" build=dev`, 1},
 		{"path from env", []string{"couper", "run", "-f", base + "/path_from_env.hcl"}, nil, `level=error msg="configuration error: token: jwt key: read error: open %s/public.pem: no such file or directory" build=dev`, 1},
+		{"path from env /w missing key", []string{"couper", "run", "-f", "public/couper.hcl", "-f", base + "/no_key_from_env.hcl"}, nil, "", 0},
 		{"undefined AC", []string{"couper", "run", "-f", base + "/04_couper.hcl"}, nil, `level=error msg="accessControl is not defined: undefined" build=dev`, 1},
 		{"empty string in allowed_methods in endpoint", []string{"couper", "run", "-f", base + "/13_couper.hcl"}, nil, `level=error msg="%s/13_couper.hcl:3,5-27: method contains invalid character(s); " build=dev`, 1},
 		{"invalid method in allowed_methods in endpoint", []string{"couper", "run", "-f", base + "/14_couper.hcl"}, nil, `level=error msg="%s/14_couper.hcl:3,5-35: method contains invalid character(s); " build=dev`, 1},

--- a/server/testdata/settings/no_key_from_env.hcl
+++ b/server/testdata/settings/no_key_from_env.hcl
@@ -1,0 +1,7 @@
+server "couper" {
+  endpoint "/down" {
+    proxy {
+      url = env.NO_ORIGIN
+    }
+  }
+}

--- a/server/testdata/settings/path_from_env.hcl
+++ b/server/testdata/settings/path_from_env.hcl
@@ -4,13 +4,13 @@ server {
 
 definitions {
   jwt "token" {
-    key_file = env.KEY
+    key_file = env.KEY_FILE
     signature_algorithm = "HS256"
   }
 }
 
 defaults {
   environment_variables = {
-    KEY = "public.pem"
+    KEY_FILE = "public.pem"
   }
 }


### PR DESCRIPTION
All config file bytes must be passed to our context constructor.

---
<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>
