### PR TITLE
Oauth2 retry 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 Unreleased changes are available as `avenga/couper:edge` container.
 
 * **Fixed**
-  * configuration related panic while loading backends with `oauth2` block which depends on other defined backends ([#524](https://github.com/avenga/couper/pull/524))
-  * erroneous retries for `oauth2` backend authorization with `retries = 0` ([#528](https://github.com/avenga/couper/pull/528))
+  * configuration related panic while loading backends with [`oauth2` block](./docs/REFERENCE.md#oauth2-cc-block) which depends on other defined backends ([#524](https://github.com/avenga/couper/pull/524))
+  * erroneous retries for [`oauth2`](./docs/REFERENCE.md#oauth2-cc-block) backend authorization with `retries = 0` ([#528](https://github.com/avenga/couper/pull/528))
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Unreleased changes are available as `avenga/couper:edge` container.
 
 * **Fixed**
   * configuration related panic while loading backends with `oauth2` block which depends on other defined backends ([#524](https://github.com/avenga/couper/pull/524))
+  * erroneous retries for `oauth2` backend authorization with `retries = 0` ([#528](https://github.com/avenga/couper/pull/528))
 
 ---
 

--- a/handler/transport/oauth2_req_auth.go
+++ b/handler/transport/oauth2_req_auth.go
@@ -82,6 +82,10 @@ func (oa *OAuth2ReqAuth) RetryWithToken(req *http.Request, res *http.Response) (
 
 	oa.memStore.Del(oa.storageKey)
 
+	if *oa.config.Retries < 1 {
+		return false, nil
+	}
+
 	ctx := req.Context()
 	if retries, ok := ctx.Value(request.TokenRequestRetries).(uint8); !ok || retries < *oa.config.Retries {
 		ctx = context.WithValue(ctx, request.TokenRequestRetries, retries+1)


### PR DESCRIPTION
Actually no retry is attempted for `oauth2 {}` with `retries = 0`

---
<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>
