### PR TITLE
add go version output to version command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Unreleased changes are available as `avenga/couper:edge` container.
 
 * **Added**
   * [`environment` block](https://docs.couper.io/configuration/block/environment), [setting](https://docs.couper.io/configuration/block/settings) and [`couper.environment` variable](https://docs.couper.io/configuration/variables#couper) ([#521](https://github.com/avenga/couper/pull/521), ([#534](https://github.com/avenga/couper/pull/534), [#545](https://github.com/avenga/couper/pull/545))
+  * used go version in `version` command ([#552](https://github.com/avenga/couper/pull/552))
 
 * **Changed**
  * Starting will now fail if `environment` blocks are used without `COUPER_ENVIRONMENT` being set ([#546](https://github.com/avenga/couper/pull/546))

--- a/command/version.go
+++ b/command/version.go
@@ -1,6 +1,8 @@
 package command
 
 import (
+	"runtime"
+	
 	"github.com/sirupsen/logrus"
 
 	"github.com/avenga/couper/config"
@@ -17,6 +19,7 @@ func NewVersion() *Version {
 
 func (v Version) Execute(_ Args, _ *config.Couper, _ *logrus.Entry) error {
 	println(utils.VersionName + " " + utils.BuildDate + " " + utils.BuildName)
+	println("go version " + runtime.Version() + " " + runtime.GOOS + "/" + runtime.GOARCH)
 	return nil
 }
 

--- a/command/version.go
+++ b/command/version.go
@@ -2,7 +2,7 @@ package command
 
 import (
 	"runtime"
-	
+
 	"github.com/sirupsen/logrus"
 
 	"github.com/avenga/couper/config"


### PR DESCRIPTION
Add go version and goos/goarch to version command output

---
<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>
