### PR TITLE
Refactor req authorizer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ test:
 	go test -v -short -race -count 1 -timeout 300s ./...
 
 test-docker:
-	docker run --rm -v $(CURDIR):/go/app -w /go/app  golang sh -c "go test -short -count 1 -v -timeout 300s -race ./..."
+	docker run --rm -v $(CURDIR):/go/app -w /go/app golang sh -c "go test -short -count 1 -v -timeout 300s -race ./..."
 
 coverage: test-coverage test-coverage-show
 

--- a/config/configload/backend.go
+++ b/config/configload/backend.go
@@ -166,7 +166,7 @@ func wrapOAuthBackend(helper *helper, parent hcl.Body) (hcl.Body, error) {
 	if err != nil {
 		return nil, err
 	}
-	
+
 	wrapped := wrapBlock(oauth2, "", backendBody)
 	parent = hclbody.MergeBodies(parent, wrapped)
 

--- a/config/runtime/backend.go
+++ b/config/runtime/backend.go
@@ -87,10 +87,10 @@ func newBackend(evalCtx *hcl.EvalContext, backendCtx hcl.Body, log *logrus.Entry
 	}
 
 	options := &transport.BackendOptions{}
-	var err error
-	options.OpenAPI, err = validation.NewOpenAPIOptions(beConf.OpenAPI)
-	if err != nil {
+	if opts, err := validation.NewOpenAPIOptions(beConf.OpenAPI); err != nil {
 		return nil, err
+	} else {
+		options.OpenAPI = opts
 	}
 
 	if beConf.Health != nil {
@@ -103,6 +103,7 @@ func newBackend(evalCtx *hcl.EvalContext, backendCtx hcl.Body, log *logrus.Entry
 			return nil, fmt.Errorf("missing origin for backend %q", beConf.Name)
 		}
 
+		var err error
 		options.HealthCheck, err = config.NewHealthCheck(origin.AsString(), beConf.Health, conf)
 		if err != nil {
 			return nil, err

--- a/config/runtime/backend.go
+++ b/config/runtime/backend.go
@@ -16,6 +16,7 @@ import (
 	"github.com/avenga/couper/config"
 	"github.com/avenga/couper/errors"
 	"github.com/avenga/couper/eval"
+	"github.com/avenga/couper/handler/producer"
 	"github.com/avenga/couper/handler/ratelimit"
 	"github.com/avenga/couper/handler/transport"
 	"github.com/avenga/couper/handler/validation"
@@ -181,7 +182,12 @@ func newRequestAuthorizer(evalCtx *hcl.EvalContext, block *hcl.Block, beConf *co
 	case *config.OAuth2ReqAuth:
 		return transport.NewOAuth2ReqAuth(impl, memStore, authorizerBackend)
 	case *config.TokenRequest:
-		return transport.NewTokenRequest(impl, memStore, authorizerBackend, beConf.Reference())
+		reqs := producer.Requests{&producer.Request{
+			Backend: authorizerBackend,
+			Context: impl.HCLBody(),
+			Name:    impl.Name,
+		}}
+		return transport.NewTokenRequest(impl, memStore, reqs, beConf.Reference())
 	default:
 		return nil, errors.Configuration.Message("unknown authorizer type")
 	}

--- a/handler/transport/oauth2_req_auth.go
+++ b/handler/transport/oauth2_req_auth.go
@@ -117,7 +117,7 @@ func (oa *OAuth2ReqAuth) RetryWithToken(req *http.Request, res *http.Response) (
 	if retries, ok := ctx.Value(request.TokenRequestRetries).(*uint8); !ok || *retries < *oa.config.Retries {
 		*retries++ // increase ptr value instead of context value
 		req.Header.Del("Authorization")
-		err := oa.GetToken(req.WithContext(ctx)) // WithContext due to header manipulation
+		err := oa.GetToken(req)
 		return true, err
 	}
 	return false, nil

--- a/server/testdata/oauth2/token_request.hcl
+++ b/server/testdata/oauth2/token_request.hcl
@@ -42,7 +42,7 @@ definitions {
     }
 
     beta_token_request "default" {
-      url = "{{.asOrigin}}/token2"
+      url = "/token2"
       query_params = {
         foo = "bar"
       }


### PR DESCRIPTION
Refactor the token-request configuration to reduce code duplication. Use already existing producer.Request to evaluate and create the outgoing request. This allows relative `url` values too.

---
<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>
