### PR TITLE
refinements for client_secret_jwt/private_key_jwt

### DIFF
--- a/oauth2/client.go
+++ b/oauth2/client.go
@@ -249,12 +249,12 @@ func (c *Client) authenticateClient(formParams *url.Values, tokenReq *http.Reque
 		claims["iat"] = now
 		claims["exp"] = now + c.authnTTL
 		claims["jti"] = identifier.String()
-		jwt, err := lib.CreateJWT(c.authnAlgo, c.authnKey, claims, c.authnHeaders)
+		clientAssertion, err := lib.CreateJWT(c.authnAlgo, c.authnKey, claims, c.authnHeaders)
 		if err != nil {
 			return err
 		}
 		formParams.Set("client_id", clientID)
-		formParams.Set("client_assertion", jwt)
+		formParams.Set("client_assertion", clientAssertion)
 		formParams.Set("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
 	default:
 		// already handled with error


### PR DESCRIPTION
do not modify client's authnClaims property, but create 'copy' and modify claims there

---
<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>
