### PR TITLE
Fix tls test expectation; handle multiple messages for same err kind

### DIFF
--- a/server/http_mtls_test.go
+++ b/server/http_mtls_test.go
@@ -104,8 +104,9 @@ func TestHTTPSServer_TLS_ServerClientCertificate(t *testing.T) {
 
 	var RemoteFailedCertCheck = func(err error) bool {
 		prefix := `Get "https://localhost:4443/": `
-		return err != nil && (err.Error() == prefix+"readLoopPeekFailLocked: remote error: tls: bad certificate" ||
-			err.Error() == prefix+"remote error: tls: bad certificate")
+		suffix := "remote error: tls: bad certificate"
+		return err != nil && (err.Error() == prefix+"readLoopPeekFailLocked: "+suffix ||
+			err.Error() == prefix+suffix)
 	}
 
 	if !RemoteFailedCertCheck(err) {

--- a/server/http_mtls_test.go
+++ b/server/http_mtls_test.go
@@ -100,12 +100,15 @@ func TestHTTPSServer_TLS_ServerClientCertificate(t *testing.T) {
 		RootCAs: pool,
 	})
 
-	res, err = client.Do(outreq)
-	if err == nil {
-		t.Fatal("expected a remote tls error")
+	_, err = client.Do(outreq)
+
+	var RemoteFailedCertCheck = func(err error) bool {
+		prefix := `Get "https://localhost:4443/": `
+		return err != nil && (err.Error() == prefix+"readLoopPeekFailLocked: remote error: tls: bad certificate" ||
+			err.Error() == prefix+"remote error: tls: bad certificate")
 	}
 
-	if err.Error() != `Get "https://localhost:4443/": remote error: tls: bad certificate` {
+	if !RemoteFailedCertCheck(err) {
 		t.Errorf("Expected a tls handshake error, got: %v", err)
 	}
 }


### PR DESCRIPTION
Also an unstable test due to its possible different err msg for same error kind

---
<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>
