### PR TITLE
Endpoint wildcard proxy wildcard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 Unreleased changes are available as `avenga/couper:edge` container.
 
+* **Fixed**
+  * Requests to wildcard (`**`) [endpoints](https://docs.couper.io/configuration/block/endpoint) using backends with a wildcard [`path` attribue](https://docs.couper.io/configuration/block/backend#attributes), where the wildcard matches the empty string (regression; since v1.11.0) ([#655](https://github.com/avenga/couper/pull/655))
+
 ---
 
 ## [1.11.1](https://github.com/avenga/couper/releases/tag/v1.11.1)

--- a/handler/producer/url.go
+++ b/handler/producer/url.go
@@ -51,10 +51,6 @@ func NewURLFromAttribute(hclCtx *hcl.EvalContext, content *hclsyntax.Body, attrN
 
 			path = utils.JoinPath("/", strings.ReplaceAll(u.Path, "/**", "/"), pathMatch)
 		}
-
-		if strings.HasSuffix(req.URL.Path, "/") && !strings.HasSuffix(path, "/") {
-			path += "/"
-		}
 	}
 
 	u.Path = path

--- a/server/http_endpoints_test.go
+++ b/server/http_endpoints_test.go
@@ -1132,3 +1132,50 @@ func TestEndpoint_ReusableProxies(t *testing.T) {
 		})
 	}
 }
+
+func TestEndpointWildcardProxyPathWildcard(t *testing.T) {
+	client := newClient()
+
+	shutdown, hook := newCouper("testdata/endpoints/21_couper.hcl", test.New(t))
+	defer shutdown()
+
+	for _, testcase := range []struct {
+		path, expectedPath string
+		statusCode         int
+	}{
+		{"/", "/", http.StatusNotFound},
+		{"/anything", "/anything", http.StatusOK},
+		{"/a/b", "/a/b", http.StatusNotFound},
+		{"/p/", "/pb/", http.StatusNotFound},
+		{"/p/a/c", "/pb/a/c", http.StatusNotFound},
+	} {
+		t.Run(testcase.path[1:], func(st *testing.T) {
+			helper := test.New(st)
+			req, err := http.NewRequest(http.MethodGet, "http://localhost:8080"+testcase.path, nil)
+			helper.Must(err)
+
+			hook.Reset()
+
+			res, err := client.Do(req)
+			helper.Must(err)
+
+			if res.StatusCode != testcase.statusCode {
+				st.Errorf("expected status %d, got %d", testcase.statusCode, res.StatusCode)
+			}
+
+			b, err := io.ReadAll(res.Body)
+			helper.Must(res.Body.Close())
+			helper.Must(err)
+
+			type result struct {
+				Path string
+			}
+			r := result{}
+			helper.Must(json.Unmarshal(b, &r))
+
+			if testcase.expectedPath != r.Path {
+				st.Errorf("Expected path: %q, got: %q", testcase.expectedPath, r.Path)
+			}
+		})
+	}
+}

--- a/server/mux.go
+++ b/server/mux.go
@@ -163,7 +163,7 @@ func (m *Mux) FindHandler(req *http.Request) http.Handler {
 		wc = strings.TrimPrefix(wc, "/")
 	}
 
-	if wc != "" {
+	if routeMatch.Route.GetName() == "**" {
 		ctx = context.WithValue(ctx, request.Wildcard, wc)
 	}
 
@@ -237,13 +237,14 @@ func mustAddRoute(root *gmux.Router, path string, handler http.Handler, trailing
 	if strings.HasSuffix(path, wildcardSearch) {
 		path = path[:len(path)-len(wildcardSearch)]
 		if len(path) == 0 {
-			path = "/" // path at least be /
+			root.PathPrefix("/").Name("**").Handler(handler)
+			return
 		}
-		root.Path(path).Handler(handler) // register /path ...
+		root.Path(path).Name("**").Handler(handler) // register /path ...
 		if !strings.HasSuffix(path, "/") {
 			path = path + "/" // ... and /path/**
 		}
-		root.PathPrefix(path).Handler(handler)
+		root.PathPrefix(path).Name("**").Handler(handler)
 		return
 	}
 

--- a/server/testdata/endpoints/21_couper.hcl
+++ b/server/testdata/endpoints/21_couper.hcl
@@ -1,0 +1,20 @@
+server {
+  endpoint "/**" {
+    proxy {
+      backend {
+        origin = "${env.COUPER_TEST_BACKEND_ADDR}"
+        path = "/**"
+      }
+    }
+  }
+
+  endpoint "/p/**" {
+    proxy {
+      backend {
+        origin = "${env.COUPER_TEST_BACKEND_ADDR}"
+        path = "/pb/**"
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Fixed endpoint wildcard/proxy wildcard combination where wildcard matches `""`:

```hcl
  endpoint "/**" {
    proxy {
      backend {
        origin = "http://localhost:8081"
        path = "/**"
      }
    }
  }

  endpoint "/a/**" {
    proxy {
      backend {
        origin = "http://localhost:8081"
        path = "/b/**"
      }
    }
  }
```
before:
* request `GET /` -> backend request `GET /**`
* request `GET /a` -> backend request `GET /b/**`

now:
* request `GET /` -> backend request `GET /`
* request `GET /a` -> backend request `GET /b`

---
BTW, without
```
        path = "/**"
```
in the first endpoint, the backend request path was ok.

Non-empty-matches were ok, too:
* request `GET /c` -> backend request `GET /c`
* request `GET /a/c` -> backend request `GET /b/c`

---
<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>
