### PR TITLE
reduce allocs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Unreleased changes are available as `avenga/couper:edge` container.
 
 * **Fixed**
   * Requests to wildcard (`**`) [endpoints](https://docs.couper.io/configuration/block/endpoint) using backends with a wildcard [`path` attribue](https://docs.couper.io/configuration/block/backend#attributes), where the wildcard matches the empty string (regression; since v1.11.0) ([#655](https://github.com/avenga/couper/pull/655))
-  * Creating request context based jwt, oauth2 and saml (hcl) functions without related definitions
+  * Creating request context based jwt, oauth2 and saml (hcl) functions without related definitions ([#666](https://github.com/avenga/couper/pull/666))
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Unreleased changes are available as `avenga/couper:edge` container.
 * **Fixed**
   * Requests to wildcard (`**`) [endpoints](https://docs.couper.io/configuration/block/endpoint) using backends with a wildcard [`path` attribue](https://docs.couper.io/configuration/block/backend#attributes), where the wildcard matches the empty string (regression; since v1.11.0) ([#655](https://github.com/avenga/couper/pull/655))
   * Creating request context based jwt, oauth2 and saml (hcl) functions without related definitions ([#666](https://github.com/avenga/couper/pull/666))
+  * Reduced allocation amount while proxying requests ([#666](https://github.com/avenga/couper/pull/666))
+  * Removing websockets related headers while the proxy `websockets` option is `false` (or no block definition) ([#666](https://github.com/avenga/couper/pull/666))
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Unreleased changes are available as `avenga/couper:edge` container.
 
 * **Fixed**
   * Requests to wildcard (`**`) [endpoints](https://docs.couper.io/configuration/block/endpoint) using backends with a wildcard [`path` attribue](https://docs.couper.io/configuration/block/backend#attributes), where the wildcard matches the empty string (regression; since v1.11.0) ([#655](https://github.com/avenga/couper/pull/655))
+  * Creating request context based jwt, oauth2 and saml (hcl) functions without related definitions
 
 ---
 

--- a/eval/context.go
+++ b/eval/context.go
@@ -410,6 +410,8 @@ func (c *Context) updateFunctions() {
 	if len(c.jwtSigningConfigs) > 0 {
 		jwtfn := lib.NewJwtSignFunction(c.eval, c.jwtSigningConfigs, Value)
 		c.eval.Functions[lib.FnJWTSign] = jwtfn
+	} else {
+		c.eval.Functions[lib.FnJWTSign] = lib.NoOpJwtSignFunction
 	}
 }
 

--- a/eval/context.go
+++ b/eval/context.go
@@ -407,20 +407,22 @@ func (c *Context) getCodeVerifier() (*pkce.CodeVerifier, error) {
 
 // updateFunctions recreates the listed functions with the current evaluation context.
 func (c *Context) updateFunctions() {
-	jwtfn := lib.NewJwtSignFunction(c.eval, c.jwtSigningConfigs, Value)
-	c.eval.Functions[lib.FnJWTSign] = jwtfn
+	if len(c.jwtSigningConfigs) > 0 {
+		jwtfn := lib.NewJwtSignFunction(c.eval, c.jwtSigningConfigs, Value)
+		c.eval.Functions[lib.FnJWTSign] = jwtfn
+	}
 }
 
 // updateRequestRelatedFunctions re-creates the listed functions for the client request context.
 func (c *Context) updateRequestRelatedFunctions(origin *url.URL) {
-	if c.oauth2 != nil {
+	if len(c.oauth2) > 0 {
 		oauth2fn := lib.NewOAuthAuthorizationURLFunction(c.eval, c.oauth2, c.getCodeVerifier, origin, Value)
 		c.eval.Functions[lib.FnOAuthAuthorizationURL] = oauth2fn
 	}
 	c.eval.Functions[lib.FnOAuthVerifier] = lib.NewOAuthCodeVerifierFunction(c.getCodeVerifier)
 	c.eval.Functions[lib.InternalFnOAuthHashedVerifier] = lib.NewOAuthCodeChallengeFunction(c.getCodeVerifier)
 
-	if c.saml != nil {
+	if len(c.saml) > 0 {
 		samlfn := lib.NewSamlSsoURLFunction(c.saml, origin)
 		c.eval.Functions[lib.FnSamlSsoURL] = samlfn
 	}

--- a/eval/lib/jwt.go
+++ b/eval/lib/jwt.go
@@ -129,6 +129,23 @@ func NewJWTSigningConfigFromJWT(j *config.JWT) (*JWTSigningConfig, error) {
 	return c, nil
 }
 
+var NoOpJwtSignFunction = function.New(&function.Spec{
+	Params: []function.Parameter{
+		{
+			Name: "jwt_signing_profile_label",
+			Type: cty.String,
+		},
+		{
+			Name: "claims",
+			Type: cty.DynamicPseudoType,
+		},
+	},
+	Type: function.StaticReturnType(cty.String),
+	Impl: func(_ []cty.Value, _ cty.Type) (ret cty.Value, err error) {
+		return cty.StringVal(""), fmt.Errorf("missing jwt_signing_profile or jwt (with signing_ttl) definitions")
+	},
+})
+
 func NewJwtSignFunction(ctx *hcl.EvalContext, jwtSigningConfigs map[string]*JWTSigningConfig,
 	evalFn func(*hcl.EvalContext, hcl.Expression) (cty.Value, error)) function.Function {
 	return function.New(&function.Spec{
@@ -145,7 +162,7 @@ func NewJwtSignFunction(ctx *hcl.EvalContext, jwtSigningConfigs map[string]*JWTS
 		Type: function.StaticReturnType(cty.String),
 		Impl: func(args []cty.Value, _ cty.Type) (ret cty.Value, err error) {
 			if len(jwtSigningConfigs) == 0 {
-				return cty.StringVal(""), fmt.Errorf("missing jwt_signing_profile or jwt (with signing_ttl) definitions")
+				return NoOpJwtSignFunction.Call(nil)
 			}
 
 			label := args[0].AsString()

--- a/handler/producer/request_test.go
+++ b/handler/producer/request_test.go
@@ -92,7 +92,7 @@ func Test_ProduceExpectedStatus(t *testing.T) {
 		proxies := producer.Proxies{&producer.Proxy{
 			Content:   content,
 			Name:      "proxy",
-			RoundTrip: handler.NewProxy(backend, content, logEntry),
+			RoundTrip: handler.NewProxy(backend, content, false, logEntry),
 		}}
 
 		testNames := []string{"request", "proxy"}

--- a/handler/transport/backend.go
+++ b/handler/transport/backend.go
@@ -482,7 +482,9 @@ func (b *Backend) withTimeout(req *http.Request, conf *Config) <-chan error {
 		defer cancelFn()
 		deadline := make(<-chan time.Time)
 		if timeout > 0 {
-			deadline = time.After(timeout)
+			deadlineTimer := time.NewTimer(timeout)
+			deadline = deadlineTimer.C
+			defer deadlineTimer.Stop()
 		}
 		select {
 		case <-deadline:


### PR DESCRIPTION
Don't create eval functions without related jwt,oauth2 or saml defintions.

fixed possible Timer leak

fixed proxy websockets behaviour

---
<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>
