### PR TITLE
functions without definitions

### DIFF
--- a/eval/context.go
+++ b/eval/context.go
@@ -421,6 +421,8 @@ func (c *Context) updateRequestRelatedFunctions(origin *url.URL) {
 	if len(c.oauth2) > 0 {
 		oauth2fn := lib.NewOAuthAuthorizationURLFunction(c.eval, c.oauth2, c.getCodeVerifier, origin, Value)
 		c.eval.Functions[lib.FnOAuthAuthorizationURL] = oauth2fn
+	} else {
+		c.eval.Functions[lib.FnOAuthAuthorizationURL] = lib.NoOpOAuthAuthorizationURLFunction
 	}
 	c.eval.Functions[lib.FnOAuthVerifier] = lib.NewOAuthCodeVerifierFunction(c.getCodeVerifier)
 	c.eval.Functions[lib.InternalFnOAuthHashedVerifier] = lib.NewOAuthCodeChallengeFunction(c.getCodeVerifier)
@@ -428,6 +430,8 @@ func (c *Context) updateRequestRelatedFunctions(origin *url.URL) {
 	if len(c.saml) > 0 {
 		samlfn := lib.NewSamlSsoURLFunction(c.saml, origin)
 		c.eval.Functions[lib.FnSamlSsoURL] = samlfn
+	} else {
+		c.eval.Functions[lib.FnSamlSsoURL] = lib.NoOpSamlSsoURLFunction
 	}
 }
 

--- a/eval/lib/oauth2_test.go
+++ b/eval/lib/oauth2_test.go
@@ -423,7 +423,6 @@ definitions {
 }
 
 func TestOAuthAuthorizationURLError(t *testing.T) {
-	t.Skip("TODO: fallback")
 	tests := []struct {
 		name    string
 		config  string

--- a/eval/lib/saml.go
+++ b/eval/lib/saml.go
@@ -18,6 +18,22 @@ const (
 	NameIDFormatUnspecified = "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified"
 )
 
+var NoOpSamlSsoURLFunction = function.New(&function.Spec{
+	Params: []function.Parameter{
+		{
+			Name: "saml_label",
+			Type: cty.String,
+		},
+	},
+	Type: function.StaticReturnType(cty.String),
+	Impl: func(args []cty.Value, _ cty.Type) (ret cty.Value, err error) {
+		if len(args) > 0 {
+			return cty.StringVal(""), fmt.Errorf("missing saml block with referenced label %q", args[0].AsString())
+		}
+		return cty.StringVal(""), fmt.Errorf("missing saml definitions")
+	},
+})
+
 func NewSamlSsoURLFunction(configs []*config.SAML, origin *url.URL) function.Function {
 	type entity struct {
 		config     *config.SAML
@@ -48,7 +64,7 @@ func NewSamlSsoURLFunction(configs []*config.SAML, origin *url.URL) function.Fun
 			label := args[0].AsString()
 			ent, exist := samlEntities[label]
 			if !exist {
-				return cty.StringVal(""), fmt.Errorf("missing saml block with referenced label %q", label)
+				return NoOpSamlSsoURLFunction.Call(args)
 			}
 
 			metadata := ent.descriptor

--- a/eval/lib/saml_test.go
+++ b/eval/lib/saml_test.go
@@ -130,7 +130,6 @@ func TestSamlConfigError(t *testing.T) {
 }
 
 func TestSamlSsoURLError(t *testing.T) {
-	t.Skip("TODO fallback")
 	tests := []struct {
 		name    string
 		config  string


### PR DESCRIPTION
treat `saml_sso_url()` and `oauth2_authorization_url()` similar to `jwt_sign()`

---
<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>
