### PR TITLE
couper help error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Unreleased changes are available as `avenga/couper:edge` container.
 * **Fixed**
   * Use of [backend-related variables](https://docs.couper.io/configuration/variables#backend) in [`custom_log_fields`](https://docs.couper.io/observation/logging#custom-logging) within a [`backend` block](https://docs.couper.io/configuration/block/backend) ([#658](https://github.com/avenga/couper/pull/658))
   * Loop with evaluation error in [`custom_log_fields`](https://docs.couper.io/observation/logging#custom-logging) if log level is `"debug"` ([#659](https://github.com/avenga/couper/pull/659))
+  * Removed error message with `couper help` [command](https://docs.couper.io/configuration/command-line) ([#678](https://github.com/avenga/couper/pull/678))
 
 ---
 

--- a/command/help.go
+++ b/command/help.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/avenga/couper/config"
 	"github.com/sirupsen/logrus"
@@ -40,15 +39,7 @@ func NewHelp(ctx context.Context) *Help {
 
 func (h Help) Execute(args Args, _ *config.Couper, _ *logrus.Entry) error {
 	defer Synopsis()
-	if len(args) == 0 {
-		h.Usage()
-		return fmt.Errorf("missing command argument")
-	}
-	cmd := NewCommand(h.ctx, args[0])
-	if cmd == nil {
-		return fmt.Errorf("unknown command: %s", args[0])
-	}
-	cmd.Usage()
+	h.Usage()
 	return nil
 }
 


### PR DESCRIPTION
help command does not expect args

---
<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>
