### PR TITLE
empty server timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 Unreleased changes are available as `avenga/couper:edge` container.
 
+* **Fixed**
+  * Erroneously sending an empty [`Server-Timing` header](https://docs.couper.io/configuration/command-line#oberservation-options) ([#700](https://github.com/avenga/couper/pull/700))
+
 ---
 
 ## [1.12.0](https://github.com/avenga/couper/releases/tag/v1.12.0)

--- a/handler/endpoint.go
+++ b/handler/endpoint.go
@@ -173,7 +173,10 @@ func (e *Endpoint) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	if e.opts.SendServerTimings {
-		rw.Header().Add(serverTimingHeader, getServerTimings(clientres.Header, beresps))
+		st := getServerTimings(clientres.Header, beresps)
+		if st != "" {
+			rw.Header().Add(serverTimingHeader, st)
+		}
 	}
 
 	// copy/write like a reverseProxy
@@ -196,6 +199,10 @@ func (e *Endpoint) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 }
 
 func getServerTimings(headers http.Header, beresps producer.ResultMap) string {
+	if len(beresps) == 0 {
+		return ""
+	}
+
 	serverTimings := make(utils.ServerTimings)
 
 	for _, h := range headers.Values(serverTimingHeader) {

--- a/server/http_test.go
+++ b/server/http_test.go
@@ -960,6 +960,17 @@ func TestHTTPServer_ServerTiming(t *testing.T) {
 	if s := strings.Join(dataCouper2, " "); !exp2.MatchString(s) {
 		t.Errorf("Unexpected header from 'second' Couper: %s", s)
 	}
+
+	req, err = http.NewRequest(http.MethodGet, "http://anyserver:9090/empty", nil)
+	helper.Must(err)
+
+	res, err = client.Do(req)
+	helper.Must(err)
+
+	headers = res.Header.Values("Server-Timing")
+	if l := len(headers); l != 0 {
+		t.Fatalf("Unexpected number of headers: %d", l)
+	}
 }
 
 func TestHTTPServer_CVE_2022_2880(t *testing.T) {

--- a/server/testdata/integration/http/01_couper.hcl
+++ b/server/testdata/integration/http/01_couper.hcl
@@ -6,6 +6,12 @@ server "first" {
       backend = "b1"
     }
   }
+
+  endpoint "/empty" {
+    response {
+      status = 204
+    }
+  }
 }
 
 settings {


### PR DESCRIPTION
Don't send empty `Server-Timing` header.

---
<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>
