### PR TITLE
fix for go1.19.6

### DIFF
--- a/handler/endpoint_test.go
+++ b/handler/endpoint_test.go
@@ -192,7 +192,7 @@ func TestEndpoint_RoundTripContext_Variables_json_body(t *testing.T) {
 		origin = "` + origin.URL + `"
 		set_request_headers = {
 			x-test = request.json_body.foo
-		}`, []string{http.MethodTrace, http.MethodHead}, test.Header{"Content-Type": "application/json"}, `{"foo": "bar"}`, want{req: test.Header{"x-test": ""}}},
+		}`, []string{http.MethodTrace}, test.Header{"Content-Type": "application/json"}, `{"foo": "bar"}`, want{req: test.Header{"x-test": ""}}},
 		{"method /wo body", `
 		origin = "` + origin.URL + `"
 		set_request_headers = {

--- a/handler/endpoint_test.go
+++ b/handler/endpoint_test.go
@@ -242,7 +242,7 @@ func TestEndpoint_RoundTripContext_Variables_json_body(t *testing.T) {
 
 				for k, v := range tt.want.req {
 					if res.Header.Get(k) != v {
-						subT.Errorf("want: %q for key %q, got: %q", v, k, res.Header[k])
+						subT.Errorf("want: %q for key %q, got: %q", v, k, res.Header.Get(k))
 					}
 				}
 			})


### PR DESCRIPTION
The test runner on github now uses go1.19.6

Fix test failing with go1.19.6

---
<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>
