### PR TITLE
738 parse cert with trailing stuff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Unreleased changes are available as `avenga/couper:edge` container.
   * `WWW-Authenticate` header `realm` param value for [`basic_auth`](https://docs.couper.io/configuration/block/basic_auth) ([#715](https://github.com/avenga/couper/pull/715))
   * [JWT access control](https://docs.couper.io/configuration/block/jwt) now creating `401` error status code, adding a `WWW-Authenticate: Bearer[...]` response header if appropriate ([#719](https://github.com/avenga/couper/pull/719))
   * Erroneous multiplying of [health probes](https://docs.couper.io/configuration/block/health), [jobs](https://docs.couper.io/configuration/block/job) and requests to [JWKS](https://docs.couper.io/configuration/block/jwt) and [OpenID configuration](https://docs.couper.io/configuration/block/oidc) resources after a reload with [`-watch`](https://docs.couper.io/configuration/command-line#basic-options) ([#730](https://github.com/avenga/couper/pull/730), [#736](https://github.com/avenga/couper/pull/736))
+  * Reading PEM-encoded CA certificates ([`ca_file` setting](https://docs.couper.io/configuration/block/settings#attributes) or [`-ca-file` option](https://docs.couper.io/configuration/command-line#tls-options)) containing bytes trailing the PEM message ([#739](https://github.com/avenga/couper/pull/739))
 
 ---
 

--- a/command/run.go
+++ b/command/run.go
@@ -175,12 +175,13 @@ func readCertificateFile(file string) ([]byte, error) {
 		return nil, fmt.Errorf("error reading ca-certificate: empty file: %q", file)
 	}
 
+	hasValidCert := false
 	pemCerts := cert[:]
 	for len(pemCerts) > 0 {
 		var block *pem.Block
 		block, pemCerts = pem.Decode(pemCerts)
 		if block == nil {
-			return nil, fmt.Errorf("error parsing pem ca-certificate: missing pem block")
+			break
 		}
 		if block.Type != "CERTIFICATE" || len(block.Headers) != 0 {
 			continue
@@ -190,6 +191,12 @@ func readCertificateFile(file string) ([]byte, error) {
 		if _, err = x509.ParseCertificate(certBytes); err != nil {
 			return nil, fmt.Errorf("error parsing pem ca-certificate: %q: %v", file, err)
 		}
+
+		hasValidCert = true
+	}
+
+	if !hasValidCert {
+		return nil, fmt.Errorf("error parsing pem ca-certificate: has no valid X509 certificate")
 	}
 
 	return cert, nil


### PR DESCRIPTION
`readCertificateFile()` ignoring trailing stuff, but failing if PEM doesn't contain any X509 certificate

---
<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>
