### PR TITLE
server-timing endpoint sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Unreleased changes are available as `avenga/couper:edge` container.
 * **Fixed**
   * Erroneously sending an empty [`Server-Timing` header](https://docs.couper.io/configuration/command-line#oberservation-options) ([#700](https://github.com/avenga/couper/pull/700))
   * `WWW-Authenticate` header `realm` param value for [`basic_auth`](https://docs.couper.io/configuration/block/basic_auth) ([#715](https://github.com/avenga/couper/pull/715))
+  * [`Server-Timing` header](https://docs.couper.io/configuration/block/settings) only reporting last requests/proxies of [endpoint sequences](https://docs.couper.io/configuration/block/endpoint#endpoint-sequence) ([#751](https://github.com/avenga/couper/pull/751))
 
 * **Dependencies**
   * build with go 1.20 ([#745](https://github.com/avenga/couper/pull/745))

--- a/server/http_test.go
+++ b/server/http_test.go
@@ -961,6 +961,37 @@ func TestHTTPServer_ServerTiming(t *testing.T) {
 		t.Errorf("Unexpected header from 'second' Couper: %s", s)
 	}
 
+	req, err = http.NewRequest(http.MethodGet, "http://anyserver:9090/seq", nil)
+	helper.Must(err)
+
+	res, err = client.Do(req)
+	helper.Must(err)
+
+	headers = res.Header.Values("Server-Timing")
+	if l := len(headers); l != 2 {
+		t.Fatalf("Unexpected number of headers: %d", 2)
+	}
+
+	dataCouper1 = strings.Split(headers[0], ", ")
+	dataCouper2 = strings.Split(headers[1], ", ")
+
+	sort.Strings(dataCouper1)
+	sort.Strings(dataCouper2)
+
+	if len(dataCouper1) != 2 || len(dataCouper2) != 5 {
+		t.Fatal("Unexpected number of metrics")
+	}
+
+	exp1 = regexp.MustCompile(`b1_total_[0-9a-f]{6};dur=\d+(.\d)* b1_ttfb_[0-9a-f]{6};dur=\d+(.\d)*`)
+	if s := strings.Join(dataCouper1, " "); !exp1.MatchString(s) {
+		t.Errorf("Unexpected header from 'first' Couper: %s", s)
+	}
+
+	exp2 = regexp.MustCompile(`b1_total;dur=\d+(.\d)* b1_ttfb;dur=\d+(.\d)* b2_REQ_tcp;dur=\d+(.\d)* b2_REQ_total;dur=\d+(.\d)* b2_REQ_ttfb;dur=\d+(.\d)*`)
+	if s := strings.Join(dataCouper2, " "); !exp2.MatchString(s) {
+		t.Errorf("Unexpected header from 'second' Couper: %s", s)
+	}
+
 	req, err = http.NewRequest(http.MethodGet, "http://anyserver:9090/empty", nil)
 	helper.Must(err)
 

--- a/server/testdata/integration/http/01_couper.hcl
+++ b/server/testdata/integration/http/01_couper.hcl
@@ -7,6 +7,12 @@ server "first" {
     }
   }
 
+  endpoint "/seq" {
+    proxy {
+      backend = "b1"
+    }
+  }
+
   endpoint "/empty" {
     response {
       status = 204

--- a/server/testdata/integration/http/02_couper.hcl
+++ b/server/testdata/integration/http/02_couper.hcl
@@ -8,6 +8,18 @@ server "second" {
       backend = "b2"
     }
   }
+  endpoint "/seq" {
+    proxy {
+      backend = "b1"
+      set_request_headers = {
+        x-req = backend_responses.REQ.status
+      }
+    }
+
+    request "REQ" {
+      backend = "b2"
+    }
+  }
 }
 
 settings {


### PR DESCRIPTION
create a result channel for every item, so that result map contains result from every item, so that server-timing uses all backend request times

---
<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>
