### PR TITLE
707 allow super kind errors, match proper error handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Unreleased changes are available as `avenga/couper:edge` container.
   * Erroneously sending an empty [`Server-Timing` header](https://docs.couper.io/configuration/command-line#oberservation-options) ([#700](https://github.com/avenga/couper/pull/700))
   * `WWW-Authenticate` header `realm` param value for [`basic_auth`](https://docs.couper.io/configuration/block/basic_auth) ([#715](https://github.com/avenga/couper/pull/715))
   * [`Server-Timing` header](https://docs.couper.io/configuration/block/settings) only reporting last requests/proxies of [endpoint sequences](https://docs.couper.io/configuration/block/endpoint#endpoint-sequence) ([#751](https://github.com/avenga/couper/pull/751))
+  * Selecting of appropriate [error handler](https://docs.couper.io/configuration/block/error_handler) in two cases ([#753](https://github.com/avenga/couper/pull/753))
 
 * **Dependencies**
   * build with go 1.20 ([#745](https://github.com/avenga/couper/pull/745))

--- a/server/http_error_handler_test.go
+++ b/server/http_error_handler_test.go
@@ -390,31 +390,25 @@ func TestErrorHandler_SuperKind(t *testing.T) {
 	defer shutdown()
 
 	type testcase struct {
-		name          string
-		path          string
-		sendToken     bool
-		sendWrongPass bool
-		expFrom       string
+		name      string
+		path      string
+		sendToken bool
+		expFrom   string
 	}
 
 	for _, tc := range []testcase{
-		{"ba: *", "/ba1", false, false, "*"},
-		{"ba: *, access_control", "/ba2", false, false, "access_control"},
-		{"ba: *, access_control, basic_auth", "/ba3", false, false, "basic_auth"},
-		{"ba: *, access_control, basic_auth, basic_auth_credentials_missing", "/ba4", false, false, "basic_auth_credentials_missing"},
-		{"ba wrong password: *, access_control, basic_auth, basic_auth_credentials_missing", "/ba4", false, true, "basic_auth"},
-		{"jwt: *", "/jwt1", true, false, "*"},
-		{"jwt: *, access_control", "/jwt2", true, false, "access_control"},
-		{"jwt: *, access_control, insufficient_permissions", "/jwt3", true, false, "insufficient_permissions"},
-		{"ep: *", "/ep1", false, false, "*"},
-		{"ep: *, endpoint", "/ep2", false, false, "endpoint"},
-		{"ep: *, endpoint, unexpected_status", "/ep3", false, false, "unexpected_status"},
-		{"be: *", "/be1", false, false, "*"},
-		{"be: *, backend", "/be2", false, false, "backend"},
-		{"be: *, backend, backend_timeout", "/be3", false, false, "backend_timeout"},
-		{"be: backend, backend_timeout", "/be4", false, false, "backend_timeout"},
-		{"be: backend", "/be5", false, false, "backend"},
-		{"be dial error: *, backend", "/be-dial", false, false, "backend"},
+		{"ac: handler for *", "/ac1", true, "*"},
+		{"ac: handlers for *, access_control", "/ac2", true, "access_control"},
+		{"ac: handlers for *, access_control, insufficient_permissions", "/ac3", true, "insufficient_permissions"},
+		{"ep: handler for *", "/ep1", false, "*"},
+		{"ep: handlers for *, endpoint", "/ep2", false, "endpoint"},
+		{"ep: handlers for *, endpoint, unexpected_status", "/ep3", false, "unexpected_status"},
+		{"be: handler for *", "/be1", false, "*"},
+		{"be: handlers for *, backend", "/be2", false, "backend"},
+		{"be: handlers for *, backend, backend_timeout", "/be3", false, "backend_timeout"},
+		{"be: handlers for backend, backend_timeout", "/be4", false, "backend_timeout"},
+		{"be: handler for backend", "/be5", false, "backend"},
+		{"be dial error: handlers for *, backend", "/be-dial", false, "backend"},
 	} {
 		t.Run(tc.name, func(st *testing.T) {
 			h := test.New(st)
@@ -422,11 +416,8 @@ func TestErrorHandler_SuperKind(t *testing.T) {
 			h.Must(err)
 
 			if tc.sendToken {
-				// not needed for non-jwt tests
+				// not needed for non-ac tests
 				req.Header.Set("Authorization", "Bearer "+token)
-			}
-			if tc.sendWrongPass {
-				req.SetBasicAuth("", "wrong")
 			}
 
 			res, err := client.Do(req)

--- a/server/testdata/integration/error_handler/09_couper.hcl
+++ b/server/testdata/integration/error_handler/09_couper.hcl
@@ -1,0 +1,457 @@
+server {
+  endpoint "/ba1" {
+    access_control = ["ba1"]
+
+    response {
+    }
+  }
+
+  endpoint "/ba2" {
+    access_control = ["ba2"]
+
+    response {
+    }
+  }
+
+  endpoint "/ba3" {
+    access_control = ["ba3"]
+
+    response {
+    }
+  }
+
+  endpoint "/ba4" {
+    access_control = ["ba4"]
+
+    response {
+    }
+  }
+
+  endpoint "/jwt1" {
+    access_control = ["at"]
+    required_permission = "rp"
+
+    response {
+    }
+
+    error_handler "*" {
+      response {
+        status = 204
+        headers = {
+          from = "*"
+        }
+      }
+    }
+  }
+
+  endpoint "/jwt2" {
+    access_control = ["at"]
+    required_permission = "rp"
+
+    response {
+    }
+
+    error_handler "*" {
+      response {
+        status = 204
+        headers = {
+          from = "*"
+        }
+      }
+    }
+
+    error_handler "access_control" {
+      response {
+        status = 204
+        headers = {
+          from = "access_control"
+        }
+      }
+    }
+  }
+
+  endpoint "/jwt3" {
+    access_control = ["at"]
+    required_permission = "rp"
+
+    response {
+    }
+
+    error_handler "*" {
+      response {
+        status = 204
+        headers = {
+          from = "*"
+        }
+      }
+    }
+
+    error_handler "access_control" {
+      response {
+        status = 204
+        headers = {
+          from = "access_control"
+        }
+      }
+    }
+
+    error_handler "insufficient_permissions" {
+      response {
+        status = 204
+        headers = {
+          from = "insufficient_permissions"
+        }
+      }
+    }
+  }
+
+  endpoint "/ep1" {
+    request "r" {
+      url = "${env.COUPER_TEST_BACKEND_ADDR}/not_there"
+      expected_status = [200]
+    }
+
+    response {
+    }
+
+    error_handler "*" {
+      response {
+        status = 204
+        headers = {
+          from = "*"
+        }
+      }
+    }
+  }
+
+  endpoint "/ep2" {
+    request "r" {
+      url = "${env.COUPER_TEST_BACKEND_ADDR}/not_there"
+      expected_status = [200]
+    }
+
+    response {
+    }
+
+    error_handler "*" {
+      response {
+        status = 204
+        headers = {
+          from = "*"
+        }
+      }
+    }
+
+    error_handler "endpoint" {
+      response {
+        status = 204
+        headers = {
+          from = "endpoint"
+        }
+      }
+    }
+  }
+
+  endpoint "/ep3" {
+    request "r" {
+      url = "${env.COUPER_TEST_BACKEND_ADDR}/not_there"
+      expected_status = [200]
+    }
+
+    response {
+    }
+
+    error_handler "*" {
+      response {
+        status = 204
+        headers = {
+          from = "*"
+        }
+      }
+    }
+
+    error_handler "endpoint" {
+      response {
+        status = 204
+        headers = {
+          from = "endpoint"
+        }
+      }
+    }
+
+    error_handler "unexpected_status" {
+      response {
+        status = 204
+        headers = {
+          from = "unexpected_status"
+        }
+      }
+    }
+  }
+
+  endpoint "/be1" {
+    proxy {
+      backend {
+        origin = "${env.COUPER_TEST_BACKEND_ADDR}"
+        timeout = "1ns"
+      }
+    }
+
+    error_handler "*" {
+      response {
+        status = 204
+        headers = {
+          from = "*"
+        }
+      }
+    }
+  }
+
+  endpoint "/be2" {
+    proxy {
+      backend {
+        origin = "${env.COUPER_TEST_BACKEND_ADDR}"
+        timeout = "1ns"
+      }
+    }
+
+    error_handler "*" {
+      response {
+        status = 204
+        headers = {
+          from = "*"
+        }
+      }
+    }
+
+    error_handler "backend" {
+      response {
+        status = 204
+        headers = {
+          from = "backend"
+        }
+      }
+    }
+  }
+
+  endpoint "/be3" {
+    proxy {
+      backend {
+        origin = "${env.COUPER_TEST_BACKEND_ADDR}"
+        timeout = "1ns"
+      }
+    }
+
+    error_handler "*" {
+      response {
+        status = 204
+        headers = {
+          from = "*"
+        }
+      }
+    }
+
+    error_handler "backend" {
+      response {
+        status = 204
+        headers = {
+          from = "backend"
+        }
+      }
+    }
+
+    error_handler "backend_timeout" {
+      response {
+        status = 204
+        headers = {
+          from = "backend_timeout"
+        }
+      }
+    }
+  }
+
+  endpoint "/be4" {
+    proxy {
+      backend {
+        origin = "${env.COUPER_TEST_BACKEND_ADDR}"
+        timeout = "1ns"
+      }
+    }
+
+    error_handler "backend" {
+      response {
+        status = 204
+        headers = {
+          from = "backend"
+        }
+      }
+    }
+
+    error_handler "backend_timeout" {
+      response {
+        status = 204
+        headers = {
+          from = "backend_timeout"
+        }
+      }
+    }
+  }
+
+  endpoint "/be5" {
+    proxy {
+      backend {
+        origin = "${env.COUPER_TEST_BACKEND_ADDR}"
+        timeout = "1ns"
+      }
+    }
+
+    error_handler "backend" {
+      response {
+        status = 204
+        headers = {
+          from = "backend"
+        }
+      }
+    }
+  }
+
+  endpoint "/be-dial" {
+    proxy {
+      backend {
+        origin = "http://unkn.own"
+      }
+    }
+
+    error_handler "*" {
+      response {
+        status = 204
+        headers = {
+          from = "*"
+        }
+      }
+    }
+
+    error_handler "backend" {
+      response {
+        status = 204
+        headers = {
+          from = "backend"
+        }
+      }
+    }
+  }
+}
+
+definitions {
+  basic_auth "ba1" {
+    password = "asdf"
+
+    error_handler "*" {
+      response {
+        status = 204
+        headers = {
+          from = "*"
+        }
+      }
+    }
+  }
+
+  basic_auth "ba2" {
+    password = "asdf"
+
+    error_handler "*" {
+      response {
+        status = 204
+        headers = {
+          from = "*"
+        }
+      }
+    }
+
+    error_handler "access_control" {
+      response {
+        status = 204
+        headers = {
+          from = "access_control"
+        }
+      }
+    }
+  }
+
+  basic_auth "ba3" {
+    password = "asdf"
+
+    error_handler "*" {
+      response {
+        status = 204
+        headers = {
+          from = "*"
+        }
+      }
+    }
+
+    error_handler "access_control" {
+      response {
+        status = 204
+        headers = {
+          from = "access_control"
+        }
+      }
+    }
+
+    error_handler "basic_auth" {
+      response {
+        status = 204
+        headers = {
+          from = "basic_auth"
+        }
+      }
+    }
+  }
+
+  basic_auth "ba4" {
+    password = "asdf"
+
+    error_handler "*" {
+      response {
+        status = 204
+        headers = {
+          from = "*"
+        }
+      }
+    }
+
+    error_handler "access_control" {
+      response {
+        status = 204
+        headers = {
+          from = "access_control"
+        }
+      }
+    }
+
+    error_handler "basic_auth" {
+      response {
+        status = 204
+        headers = {
+          from = "basic_auth"
+        }
+      }
+    }
+
+    error_handler "basic_auth_credentials_missing" {
+      response {
+        status = 204
+        headers = {
+          from = "basic_auth_credentials_missing"
+        }
+      }
+    }
+  }
+
+  jwt "at" {
+    signature_algorithm = "HS256"
+    key = "asdf"
+    permissions_claim = "p"
+  }
+}

--- a/server/testdata/integration/error_handler/09_couper.hcl
+++ b/server/testdata/integration/error_handler/09_couper.hcl
@@ -1,33 +1,5 @@
 server {
-  endpoint "/ba1" {
-    access_control = ["ba1"]
-
-    response {
-    }
-  }
-
-  endpoint "/ba2" {
-    access_control = ["ba2"]
-
-    response {
-    }
-  }
-
-  endpoint "/ba3" {
-    access_control = ["ba3"]
-
-    response {
-    }
-  }
-
-  endpoint "/ba4" {
-    access_control = ["ba4"]
-
-    response {
-    }
-  }
-
-  endpoint "/jwt1" {
+  endpoint "/ac1" {
     access_control = ["at"]
     required_permission = "rp"
 
@@ -44,7 +16,7 @@ server {
     }
   }
 
-  endpoint "/jwt2" {
+  endpoint "/ac2" {
     access_control = ["at"]
     required_permission = "rp"
 
@@ -70,7 +42,7 @@ server {
     }
   }
 
-  endpoint "/jwt3" {
+  endpoint "/ac3" {
     access_control = ["at"]
     required_permission = "rp"
 
@@ -343,112 +315,6 @@ server {
 }
 
 definitions {
-  basic_auth "ba1" {
-    password = "asdf"
-
-    error_handler "*" {
-      response {
-        status = 204
-        headers = {
-          from = "*"
-        }
-      }
-    }
-  }
-
-  basic_auth "ba2" {
-    password = "asdf"
-
-    error_handler "*" {
-      response {
-        status = 204
-        headers = {
-          from = "*"
-        }
-      }
-    }
-
-    error_handler "access_control" {
-      response {
-        status = 204
-        headers = {
-          from = "access_control"
-        }
-      }
-    }
-  }
-
-  basic_auth "ba3" {
-    password = "asdf"
-
-    error_handler "*" {
-      response {
-        status = 204
-        headers = {
-          from = "*"
-        }
-      }
-    }
-
-    error_handler "access_control" {
-      response {
-        status = 204
-        headers = {
-          from = "access_control"
-        }
-      }
-    }
-
-    error_handler "basic_auth" {
-      response {
-        status = 204
-        headers = {
-          from = "basic_auth"
-        }
-      }
-    }
-  }
-
-  basic_auth "ba4" {
-    password = "asdf"
-
-    error_handler "*" {
-      response {
-        status = 204
-        headers = {
-          from = "*"
-        }
-      }
-    }
-
-    error_handler "access_control" {
-      response {
-        status = 204
-        headers = {
-          from = "access_control"
-        }
-      }
-    }
-
-    error_handler "basic_auth" {
-      response {
-        status = 204
-        headers = {
-          from = "basic_auth"
-        }
-      }
-    }
-
-    error_handler "basic_auth_credentials_missing" {
-      response {
-        status = 204
-        headers = {
-          from = "basic_auth_credentials_missing"
-        }
-      }
-    }
-  }
-
   jwt "at" {
     signature_algorithm = "HS256"
     key = "asdf"


### PR DESCRIPTION
* I opted against inventing new specific error type and instead allowed for generic types (like "backend") to be registered in `handlersPerKind` (only "*" is deleted).
* By sorting the keys in `superKindMap` in reverse order, "*" now comes last, registering only for the remaining "free" error types.

---
<details>
    <summary>Reviewer checklist</summary>
    <ul>
        <li>Read PR description: a summary about the changes is required</li>
        <li>Changelog updated</li>
        <li>Documentation: docs/{Reference, Cli, ...}, Docker and cli help/usage</li>
        <li>Pulled branch, manually tested</li>
        <li>Verified requirements are met</li>
        <li>Reviewed the code</li>
        <li>Reviewed the related tests</li>
    </ul>
</details>
